### PR TITLE
docs: Add design document and contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,251 @@
+# Contributing to FileView
+
+FileViewへの貢献に感謝します。本ドキュメントでは、開発に参加する際のルールとガイドラインを定めます。
+
+## Table of Contents
+
+- [Development Setup](#development-setup)
+- [Coding Standards](#coding-standards)
+- [Git Workflow](#git-workflow)
+- [Commit Convention](#commit-convention)
+- [Pull Request Guidelines](#pull-request-guidelines)
+
+---
+
+## Development Setup
+
+### Prerequisites
+
+- Rust 1.75.0+
+- cargo
+- Git
+
+### Build
+
+```bash
+git clone https://github.com/Hiro-Chiba/fileview.git
+cd fileview
+cargo build
+cargo test
+```
+
+---
+
+## Coding Standards
+
+### Naming Conventions
+
+| Item | Convention | Example |
+|------|------------|---------|
+| Variables | snake_case | `file_path`, `tree_state` |
+| Functions | snake_case | `get_entries()`, `render_tree()` |
+| Types/Structs | PascalCase | `AppState`, `FileEntry` |
+| Enums | PascalCase | `OperationMode` |
+| Enum Variants | PascalCase | `OperationMode::Normal` |
+| Constants | SCREAMING_SNAKE_CASE | `MAX_PREVIEW_LINES` |
+| Modules | snake_case | `file_system`, `event_handler` |
+| Traits | PascalCase | `Renderable`, `FileOperation` |
+
+### Code Style
+
+- **インデント**: スペース4つ
+- **行の長さ**: 最大100文字（ドキュメントは80文字推奨）
+- **import順序**:
+  1. 標準ライブラリ (`std::`)
+  2. 外部クレート
+  3. 内部モジュール (`crate::`, `super::`)
+
+```rust
+// Good
+use std::path::PathBuf;
+
+use ratatui::Frame;
+use tokio::sync::mpsc;
+
+use crate::app::AppState;
+use crate::event::Event;
+```
+
+### Documentation
+
+- 公開API（`pub`）には必ずドキュメントコメント（`///`）を付ける
+- 複雑なロジックにはインラインコメント（`//`）を付ける
+- TODOコメントは `// TODO(username): description` 形式
+
+### Error Handling
+
+- `unwrap()` / `expect()` は原則禁止（テストコード除く）
+- エラーは `thiserror` で定義し、`Result<T, E>` で返す
+- 致命的エラーのみ `panic!`
+
+---
+
+## Git Workflow
+
+### Branch Strategy
+
+```
+main
+  │
+  └── feature/xxx    # 新機能開発
+  └── fix/xxx        # バグ修正
+  └── refactor/xxx   # リファクタリング
+  └── docs/xxx       # ドキュメント更新
+  └── test/xxx       # テスト追加
+```
+
+### Branch Naming
+
+```
+<type>/<short-description>
+
+Examples:
+  feature/add-preview-panel
+  fix/tree-scroll-overflow
+  refactor/event-handler
+  docs/update-readme
+```
+
+---
+
+## Commit Convention
+
+[Conventional Commits](https://www.conventionalcommits.org/) に準拠する。
+
+### Format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+### Type
+
+| Type | Description |
+|------|-------------|
+| `feat` | 新機能追加 |
+| `fix` | バグ修正 |
+| `docs` | ドキュメントのみの変更 |
+| `style` | コードの意味に影響しない変更（空白、フォーマット等） |
+| `refactor` | バグ修正でも機能追加でもないコード変更 |
+| `perf` | パフォーマンス改善 |
+| `test` | テストの追加・修正 |
+| `chore` | ビルドプロセスや補助ツールの変更 |
+
+### Scope (optional)
+
+変更対象のモジュールを指定:
+- `ui`, `event`, `fs`, `config`, `app`
+
+### Subject
+
+- 命令形で記述（"Add", "Fix", "Update"）
+- 先頭は大文字
+- 末尾にピリオドを付けない
+- 50文字以内
+
+### Examples
+
+```bash
+# Good
+feat(ui): Add syntax highlighting to preview panel
+fix(fs): Handle symlink loop detection
+refactor(event): Extract key binding logic to separate module
+docs: Update installation instructions
+chore: Bump ratatui to 0.26
+
+# Bad
+added new feature          # 命令形でない、typeがない
+feat: Fixed bug            # typeとsubjectが矛盾
+FEAT(UI): ADD FEATURE.     # 大文字すぎ、ピリオド
+```
+
+### Breaking Changes
+
+破壊的変更がある場合は `!` を追加し、footerに `BREAKING CHANGE:` を記述:
+
+```
+feat(config)!: Change configuration file format
+
+BREAKING CHANGE: Configuration file format changed from JSON to TOML.
+Migrate existing config.json to config.toml.
+```
+
+---
+
+## Pull Request Guidelines
+
+### Before Creating PR
+
+1. **テスト通過を確認**
+   ```bash
+   cargo test
+   cargo clippy -- -D warnings
+   cargo fmt --check
+   ```
+
+2. **コミット履歴を整理**
+   - 意味のある単位でコミットをまとめる
+   - WIPコミットは squash する
+
+3. **ブランチを最新に**
+   ```bash
+   git fetch origin
+   git rebase origin/main
+   ```
+
+### PR Title
+
+コミットメッセージと同じ形式を使用:
+
+```
+feat(ui): Add file preview panel
+```
+
+### PR Description Template
+
+```markdown
+## Summary
+
+変更内容の概要を1-3行で記述
+
+## Changes
+
+- 変更点1
+- 変更点2
+- 変更点3
+
+## Test Plan
+
+- [ ] テスト項目1
+- [ ] テスト項目2
+
+## Screenshots (if applicable)
+
+UIの変更がある場合はスクリーンショットを添付
+
+## Related Issues
+
+Closes #123
+```
+
+### Review Process
+
+1. 自動チェック（CI）がすべてパス
+2. 1名以上のレビュー承認
+3. コンフリクトがない状態
+4. Squash merge で main にマージ
+
+### Merge Strategy
+
+- **Squash and merge**: 複数コミットを1つにまとめてマージ
+- マージコミットメッセージはPRタイトルを使用
+
+---
+
+## Questions?
+
+不明点があれば、Issue を作成してください。

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,229 @@
+# FileView - Design Document
+
+## 1. Overview
+
+FileViewは、ターミナルエミュレーター上で動作するVSCode風のミニマルファイルツリーUIである。
+Ghostty等のモダンターミナルでの使用を想定し、**軽量・高速・直感操作**を設計思想の中核とする。
+
+### 1.1 設計思想
+
+- **View-First Architecture**: ファイルシステムの「閲覧」を最優先とし、編集機能は補助的位置づけ
+- **Event-Driven Design**: 全操作をイベントとして抽象化し、疎結合な構成を実現
+- **Lazy Evaluation**: 必要になるまでデータを読み込まない遅延評価戦略
+- **Single Source of Truth**: アプリケーション状態を単一のStateオブジェクトで管理
+
+## 2. Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    FileView                         │
+├─────────────────────────────────────────────────────┤
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐ │
+│  │   View      │  │  Controller │  │    Model    │ │
+│  │  (TUI)      │◄─┤  (Events)   │◄─┤  (State)    │ │
+│  └─────────────┘  └─────────────┘  └─────────────┘ │
+│         │                │                │        │
+│         └────────────────┼────────────────┘        │
+│                          ▼                         │
+│                 ┌─────────────────┐                │
+│                 │   FileSystem    │                │
+│                 │   Abstraction   │                │
+│                 └─────────────────┘                │
+└─────────────────────────────────────────────────────┘
+```
+
+### 2.1 レイヤー構成
+
+| Layer | Responsibility |
+|-------|----------------|
+| View | TUI描画、ユーザー入力受付 |
+| Controller | イベント処理、ビジネスロジック |
+| Model | アプリケーション状態管理 |
+| FileSystem | OS抽象化、ファイル操作 |
+
+## 3. Technology Stack
+
+| Category | Choice | Rationale |
+|----------|--------|-----------|
+| Language | Rust | メモリ安全性、高速性、クロスプラットフォーム |
+| TUI Framework | ratatui | アクティブな開発、豊富なウィジェット |
+| Async Runtime | tokio | 非同期I/O、ファイル監視 |
+| Serialization | serde | 設定ファイル、状態永続化 |
+
+## 4. Core Features
+
+### 4.1 ファイルツリー表示
+
+- 階層構造のインデント表示
+- フォルダ展開/折りたたみ（遅延読み込み）
+- アイコン表示（Nerd Fonts対応）
+- ファイルタイプ別カラーリング
+
+### 4.2 ファイル操作
+
+| Operation | Shortcut | Description |
+|-----------|----------|-------------|
+| Create | `a` | 新規ファイル/フォルダ作成 |
+| Rename | `r` | 名前変更 |
+| Delete | `d` | 削除（確認プロンプト付き） |
+| Copy | `y` | クリップボードにコピー |
+| Paste | `p` | ペースト |
+| Move | `m` | 移動モード |
+
+### 4.3 ドラッグ&ドロップ
+
+- OSC 52エスケープシーケンスによるパス取得
+- ターミナルからのドロップイベント検知
+- コピー先ディレクトリの自動判定
+
+### 4.4 クイックプレビュー
+
+| Type | Preview |
+|------|---------|
+| Text | 先頭N行のシンタックスハイライト表示 |
+| Image | Sixel/Kittyプロトコルによるサムネイル |
+| Binary | ファイルサイズ、MIMEタイプ、先頭バイト |
+
+### 4.5 パス連携
+
+- 選択中アイテムのパスを標準出力/クリップボード/環境変数へエクスポート
+- 外部コマンド実行時のパス展開（`$FILEVIEW_SELECTED`）
+
+## 5. Directory Structure
+
+```
+fileview/
+├── src/
+│   ├── main.rs              # エントリーポイント
+│   ├── app.rs               # アプリケーション状態
+│   ├── event/
+│   │   ├── mod.rs           # イベントモジュール
+│   │   ├── handler.rs       # イベントハンドラー
+│   │   └── key.rs           # キーバインド定義
+│   ├── ui/
+│   │   ├── mod.rs           # UIモジュール
+│   │   ├── tree.rs          # ツリービュー
+│   │   ├── preview.rs       # プレビューパネル
+│   │   └── statusbar.rs     # ステータスバー
+│   ├── fs/
+│   │   ├── mod.rs           # ファイルシステムモジュール
+│   │   ├── entry.rs         # ファイル/ディレクトリエントリ
+│   │   ├── operations.rs    # CRUD操作
+│   │   └── watcher.rs       # ファイル監視
+│   └── config/
+│       ├── mod.rs           # 設定モジュール
+│       └── theme.rs         # テーマ設定
+├── docs/
+│   └── DESIGN.md            # 本ドキュメント
+├── tests/
+│   └── integration/         # 統合テスト
+├── Cargo.toml
+├── CONTRIBUTING.md
+├── LICENSE
+└── README.md
+```
+
+## 6. State Management
+
+```rust
+pub struct AppState {
+    // ツリー状態
+    tree: TreeState,
+    // 選択状態
+    selection: SelectionState,
+    // プレビュー状態
+    preview: PreviewState,
+    // 操作モード
+    mode: OperationMode,
+    // 設定
+    config: Config,
+}
+
+pub enum OperationMode {
+    Normal,
+    Search,
+    Rename,
+    Confirm(ConfirmAction),
+}
+```
+
+## 7. Event Flow
+
+```
+User Input
+    │
+    ▼
+┌─────────────┐
+│ EventLoop   │ ─── キー/マウスイベント取得
+└─────────────┘
+    │
+    ▼
+┌─────────────┐
+│ Dispatcher  │ ─── イベントをActionに変換
+└─────────────┘
+    │
+    ▼
+┌─────────────┐
+│ Handler     │ ─── Actionに基づき状態更新
+└─────────────┘
+    │
+    ▼
+┌─────────────┐
+│ Renderer    │ ─── 状態からUIを再描画
+└─────────────┘
+```
+
+## 8. Preview Strategy
+
+プレビューは**非同期**かつ**キャッシュ付き**で実装する。
+
+```
+Selection Changed
+    │
+    ▼
+Debounce (100ms)
+    │
+    ▼
+Check Cache ──── Hit ───► Render from Cache
+    │
+    Miss
+    │
+    ▼
+Spawn Preview Task
+    │
+    ▼
+Load Content (async)
+    │
+    ▼
+Update Cache & Render
+```
+
+## 9. Configuration
+
+`~/.config/fileview/config.toml`:
+
+```toml
+[general]
+show_hidden = false
+follow_symlinks = true
+
+[preview]
+enabled = true
+max_lines = 50
+image_protocol = "auto"  # auto | sixel | kitty | none
+
+[theme]
+style = "default"  # default | minimal | colorful
+
+[keybindings]
+quit = "q"
+up = "k"
+down = "j"
+```
+
+## 10. Future Considerations
+
+- Git統合（変更ステータス表示）
+- ファジーファインダー統合
+- マルチペイン対応
+- プラグインシステム


### PR DESCRIPTION
## Summary

FileViewプロジェクトの初期設計ドキュメントと開発ガイドラインを追加

## Changes

- `docs/DESIGN.md`: アーキテクチャ、技術スタック、機能仕様の設計書
- `CONTRIBUTING.md`: コーディング規約、Git/PRルールの定義

### 設計ドキュメント (DESIGN.md)
- View-First / Event-Driven / Lazy Evaluation の設計思想
- Rust + ratatui + tokio の技術スタック
- モジュール分割とディレクトリ構造
- 状態管理とイベントフローの定義
- プレビュー戦略（非同期 + キャッシュ）

### 開発ガイドライン (CONTRIBUTING.md)
- 命名規約: snake_case (変数/関数), PascalCase (型), SCREAMING_SNAKE_CASE (定数)
- ブランチ戦略: feature/, fix/, refactor/, docs/
- Conventional Commits 準拠のコミットルール
- PR作成・レビュープロセス

## Test Plan

- [x] Markdownの構文確認
- [x] 内容の整合性確認