### PR TITLE
chore: Initialize Rust project with CI and module structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo clippy -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "fileview"
+version = "0.1.0"
+edition = "2021"
+description = "A minimal file tree UI for terminal emulators"
+authors = ["Hiro-Chiba"]
+license = "MIT"
+repository = "https://github.com/Hiro-Chiba/fileview"
+keywords = ["tui", "file-browser", "terminal", "cli"]
+categories = ["command-line-utilities"]
+
+[[bin]]
+name = "fv"
+path = "src/main.rs"
+
+[dependencies]
+ratatui = "0.28"
+crossterm = "0.28"
+anyhow = "1.0"
+arboard = "3.4"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
+
+[dev-dependencies]
+tempfile = "3"
+
+[profile.release]
+lto = true
+strip = true
+opt-level = "z"
+codegen-units = 1

--- a/src/action/clipboard.rs
+++ b/src/action/clipboard.rs
@@ -1,0 +1,53 @@
+//! Clipboard management for copy/cut/paste operations
+
+use std::path::PathBuf;
+
+/// Clipboard content type
+#[derive(Debug, Clone)]
+pub enum ClipboardContent {
+    Copy(Vec<PathBuf>),
+    Cut(Vec<PathBuf>),
+}
+
+/// Clipboard state
+#[derive(Debug, Default)]
+pub struct Clipboard {
+    content: Option<ClipboardContent>,
+}
+
+impl Clipboard {
+    /// Create new empty clipboard
+    pub fn new() -> Self {
+        Self { content: None }
+    }
+
+    /// Copy paths to clipboard
+    pub fn copy(&mut self, paths: Vec<PathBuf>) {
+        self.content = Some(ClipboardContent::Copy(paths));
+    }
+
+    /// Cut paths to clipboard
+    pub fn cut(&mut self, paths: Vec<PathBuf>) {
+        self.content = Some(ClipboardContent::Cut(paths));
+    }
+
+    /// Get clipboard content
+    pub fn content(&self) -> Option<&ClipboardContent> {
+        self.content.as_ref()
+    }
+
+    /// Take clipboard content (clears it)
+    pub fn take(&mut self) -> Option<ClipboardContent> {
+        self.content.take()
+    }
+
+    /// Check if clipboard has cut content
+    pub fn is_cut(&self) -> bool {
+        matches!(self.content, Some(ClipboardContent::Cut(_)))
+    }
+
+    /// Clear clipboard
+    pub fn clear(&mut self) {
+        self.content = None;
+    }
+}

--- a/src/action/file.rs
+++ b/src/action/file.rs
@@ -1,0 +1,88 @@
+//! File operations (create, rename, delete, copy)
+
+use std::path::{Path, PathBuf};
+
+/// Create a new file
+pub fn create_file(parent: &Path, name: &str) -> anyhow::Result<PathBuf> {
+    let path = parent.join(name);
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)?;
+    Ok(path)
+}
+
+/// Create a new directory
+pub fn create_dir(parent: &Path, name: &str) -> anyhow::Result<PathBuf> {
+    let path = parent.join(name);
+    std::fs::create_dir(&path)?;
+    Ok(path)
+}
+
+/// Rename a file or directory
+pub fn rename(path: &Path, new_name: &str) -> anyhow::Result<PathBuf> {
+    let new_path = path.parent().unwrap_or(Path::new("")).join(new_name);
+    std::fs::rename(path, &new_path)?;
+    Ok(new_path)
+}
+
+/// Delete a file or directory
+pub fn delete(path: &Path) -> anyhow::Result<()> {
+    if path.is_dir() {
+        std::fs::remove_dir_all(path)?;
+    } else {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+/// Copy a file to a destination directory
+pub fn copy_to(src: &Path, dest_dir: &Path) -> anyhow::Result<PathBuf> {
+    let file_name = src.file_name().ok_or_else(|| anyhow::anyhow!("Invalid source path"))?;
+    let dest = get_unique_path(&dest_dir.join(file_name));
+
+    if src.is_dir() {
+        copy_dir_recursive(src, &dest)?;
+    } else {
+        std::fs::copy(src, &dest)?;
+    }
+    Ok(dest)
+}
+
+/// Get a unique path by appending _1, _2, etc. if needed
+fn get_unique_path(path: &Path) -> PathBuf {
+    if !path.exists() {
+        return path.to_path_buf();
+    }
+
+    let stem = path.file_stem().unwrap_or_default().to_string_lossy();
+    let ext = path.extension().map(|e| format!(".{}", e.to_string_lossy())).unwrap_or_default();
+    let parent = path.parent().unwrap_or(Path::new(""));
+
+    let mut counter = 1;
+    loop {
+        let new_name = format!("{}_{}{}", stem, counter, ext);
+        let new_path = parent.join(new_name);
+        if !new_path.exists() {
+            return new_path;
+        }
+        counter += 1;
+    }
+}
+
+/// Copy directory recursively
+fn copy_dir_recursive(src: &Path, dest: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dest)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dest_path)?;
+        } else {
+            std::fs::copy(&src_path, &dest_path)?;
+        }
+    }
+    Ok(())
+}

--- a/src/action/file.rs
+++ b/src/action/file.rs
@@ -38,7 +38,9 @@ pub fn delete(path: &Path) -> anyhow::Result<()> {
 
 /// Copy a file to a destination directory
 pub fn copy_to(src: &Path, dest_dir: &Path) -> anyhow::Result<PathBuf> {
-    let file_name = src.file_name().ok_or_else(|| anyhow::anyhow!("Invalid source path"))?;
+    let file_name = src
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("Invalid source path"))?;
     let dest = get_unique_path(&dest_dir.join(file_name));
 
     if src.is_dir() {
@@ -56,7 +58,10 @@ fn get_unique_path(path: &Path) -> PathBuf {
     }
 
     let stem = path.file_stem().unwrap_or_default().to_string_lossy();
-    let ext = path.extension().map(|e| format!(".{}", e.to_string_lossy())).unwrap_or_default();
+    let ext = path
+        .extension()
+        .map(|e| format!(".{}", e.to_string_lossy()))
+        .unwrap_or_default();
     let parent = path.parent().unwrap_or(Path::new(""));
 
     let mut counter = 1;

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -1,0 +1,6 @@
+//! Action module - File operations and clipboard
+
+pub mod clipboard;
+pub mod file;
+
+pub use clipboard::Clipboard;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,7 @@
+//! Core module - Application state and view modes
+
+pub mod mode;
+pub mod state;
+
+pub use mode::{InputPurpose, PendingAction, ViewMode};
+pub use state::AppState;

--- a/src/core/mode.rs
+++ b/src/core/mode.rs
@@ -1,0 +1,46 @@
+//! View mode definitions
+
+use std::path::PathBuf;
+
+/// Current view/input mode with embedded state
+#[derive(Debug, Clone, PartialEq)]
+pub enum ViewMode {
+    /// Normal browsing mode
+    Browse,
+    /// Search mode with query
+    Search { query: String },
+    /// Text input mode
+    Input {
+        purpose: InputPurpose,
+        buffer: String,
+        cursor: usize,
+    },
+    /// Confirmation dialog
+    Confirm { action: PendingAction },
+    /// Fullscreen preview
+    Preview { scroll: usize },
+}
+
+impl Default for ViewMode {
+    fn default() -> Self {
+        Self::Browse
+    }
+}
+
+/// Purpose of text input
+#[derive(Debug, Clone, PartialEq)]
+pub enum InputPurpose {
+    /// Creating a new file
+    CreateFile,
+    /// Creating a new directory
+    CreateDir,
+    /// Renaming an existing item
+    Rename { original: PathBuf },
+}
+
+/// Action pending confirmation
+#[derive(Debug, Clone, PartialEq)]
+pub enum PendingAction {
+    /// Delete files/directories
+    Delete { targets: Vec<PathBuf> },
+}

--- a/src/core/mode.rs
+++ b/src/core/mode.rs
@@ -3,9 +3,10 @@
 use std::path::PathBuf;
 
 /// Current view/input mode with embedded state
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum ViewMode {
     /// Normal browsing mode
+    #[default]
     Browse,
     /// Search mode with query
     Search { query: String },
@@ -19,12 +20,6 @@ pub enum ViewMode {
     Confirm { action: PendingAction },
     /// Fullscreen preview
     Preview { scroll: usize },
-}
-
-impl Default for ViewMode {
-    fn default() -> Self {
-        Self::Browse
-    }
 }
 
 /// Purpose of text input

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,0 +1,67 @@
+//! Application state management
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use super::ViewMode;
+
+/// Main application state
+pub struct AppState {
+    /// Root directory path
+    pub root: PathBuf,
+    /// Current focus index in visible entries
+    pub focus_index: usize,
+    /// Top of viewport (scroll position)
+    pub viewport_top: usize,
+    /// Selected paths (multi-select)
+    pub selected_paths: HashSet<PathBuf>,
+    /// Current view mode
+    pub mode: ViewMode,
+    /// Status message
+    pub message: Option<String>,
+    /// Preview panel visibility
+    pub preview_visible: bool,
+    /// Whether to show hidden files
+    pub show_hidden: bool,
+    /// Exit flag
+    pub should_quit: bool,
+    /// Pick mode (--pick option)
+    pub pick_mode: bool,
+}
+
+impl AppState {
+    /// Create new application state
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root,
+            focus_index: 0,
+            viewport_top: 0,
+            selected_paths: HashSet::new(),
+            mode: ViewMode::Browse,
+            message: None,
+            preview_visible: false,
+            show_hidden: false,
+            should_quit: false,
+            pick_mode: false,
+        }
+    }
+
+    /// Adjust viewport to keep focus visible
+    pub fn adjust_viewport(&mut self, visible_height: usize) {
+        if self.focus_index < self.viewport_top {
+            self.viewport_top = self.focus_index;
+        } else if self.focus_index >= self.viewport_top + visible_height {
+            self.viewport_top = self.focus_index.saturating_sub(visible_height) + 1;
+        }
+    }
+
+    /// Set status message
+    pub fn set_message(&mut self, msg: impl Into<String>) {
+        self.message = Some(msg.into());
+    }
+
+    /// Clear status message
+    pub fn clear_message(&mut self) {
+        self.message = None;
+    }
+}

--- a/src/handler/key.rs
+++ b/src/handler/key.rs
@@ -1,0 +1,3 @@
+//! Keyboard event handling
+
+// TODO: Implement key handling

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1,0 +1,4 @@
+//! Handler module - Input event handling
+
+pub mod key;
+pub mod mouse;

--- a/src/handler/mouse.rs
+++ b/src/handler/mouse.rs
@@ -1,0 +1,3 @@
+//! Mouse event handling
+
+// TODO: Implement mouse handling

--- a/src/integrate/callback.rs
+++ b/src/integrate/callback.rs
@@ -1,0 +1,3 @@
+//! Callback execution (--on-select option)
+
+// TODO: Implement callback execution

--- a/src/integrate/mod.rs
+++ b/src/integrate/mod.rs
@@ -1,0 +1,4 @@
+//! Integrate module - External integration features
+
+pub mod callback;
+pub mod pick;

--- a/src/integrate/pick.rs
+++ b/src/integrate/pick.rs
@@ -1,0 +1,3 @@
+//! Pick mode (--pick option)
+
+// TODO: Implement pick mode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+//! FileView - A minimal file tree UI for terminal emulators
+//!
+//! This crate provides a VSCode-like file explorer TUI,
+//! designed for use in modern terminal emulators like Ghostty.
+
+pub mod action;
+pub mod core;
+pub mod handler;
+pub mod integrate;
+pub mod render;
+pub mod tree;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("fileview - A minimal file tree UI");
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,0 +1,5 @@
+//! Render module - UI rendering
+
+pub mod preview;
+pub mod status;
+pub mod tree;

--- a/src/render/preview.rs
+++ b/src/render/preview.rs
@@ -1,0 +1,3 @@
+//! Preview rendering (text, image, binary)
+
+// TODO: Implement preview rendering

--- a/src/render/status.rs
+++ b/src/render/status.rs
@@ -1,0 +1,3 @@
+//! Status bar rendering
+
+// TODO: Implement status bar rendering

--- a/src/render/tree.rs
+++ b/src/render/tree.rs
@@ -1,0 +1,3 @@
+//! Tree rendering
+
+// TODO: Implement tree rendering

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,0 +1,7 @@
+//! Tree module - File tree data structure and navigation
+
+pub mod navigator;
+pub mod node;
+
+pub use navigator::TreeNavigator;
+pub use node::TreeEntry;

--- a/src/tree/navigator.rs
+++ b/src/tree/navigator.rs
@@ -51,9 +51,10 @@ impl TreeNavigator {
 
     /// Toggle expand/collapse for entry at path
     pub fn toggle_expand(&mut self, path: &Path) -> anyhow::Result<()> {
+        let show_hidden = self.show_hidden;
         if let Some(entry) = self.find_entry_mut(path) {
             if entry.is_dir && !entry.is_expanded() && entry.children().is_empty() {
-                entry.load_children(self.show_hidden)?;
+                entry.load_children(show_hidden)?;
             }
             entry.toggle_expanded();
         }
@@ -62,9 +63,10 @@ impl TreeNavigator {
 
     /// Expand entry at path
     pub fn expand(&mut self, path: &Path) -> anyhow::Result<()> {
+        let show_hidden = self.show_hidden;
         if let Some(entry) = self.find_entry_mut(path) {
             if entry.is_dir && entry.children().is_empty() {
-                entry.load_children(self.show_hidden)?;
+                entry.load_children(show_hidden)?;
             }
             entry.set_expanded(true);
         }

--- a/src/tree/navigator.rs
+++ b/src/tree/navigator.rs
@@ -1,0 +1,135 @@
+//! Tree navigator - handles tree traversal and flattening
+
+use std::path::{Path, PathBuf};
+
+use super::TreeEntry;
+
+/// Manages file tree navigation
+pub struct TreeNavigator {
+    /// Root entry
+    root: TreeEntry,
+    /// Whether to show hidden files
+    show_hidden: bool,
+}
+
+impl TreeNavigator {
+    /// Create a new navigator for the given root path
+    pub fn new(root_path: &Path, show_hidden: bool) -> anyhow::Result<Self> {
+        let mut root = TreeEntry::new(root_path.to_path_buf(), 0);
+        root.load_children(show_hidden)?;
+        root.set_expanded(true);
+
+        Ok(Self { root, show_hidden })
+    }
+
+    /// Get root entry
+    pub fn root(&self) -> &TreeEntry {
+        &self.root
+    }
+
+    /// Flatten the tree into a list of visible entries
+    pub fn visible_entries(&self) -> Vec<&TreeEntry> {
+        let mut entries = Vec::new();
+        self.collect_visible(&self.root, &mut entries);
+        entries
+    }
+
+    /// Recursively collect visible entries
+    fn collect_visible<'a>(&'a self, entry: &'a TreeEntry, out: &mut Vec<&'a TreeEntry>) {
+        out.push(entry);
+        if entry.is_expanded() {
+            for child in entry.children() {
+                self.collect_visible(child, out);
+            }
+        }
+    }
+
+    /// Get total count of visible entries
+    pub fn visible_count(&self) -> usize {
+        self.visible_entries().len()
+    }
+
+    /// Toggle expand/collapse for entry at path
+    pub fn toggle_expand(&mut self, path: &Path) -> anyhow::Result<()> {
+        if let Some(entry) = self.find_entry_mut(path) {
+            if entry.is_dir && !entry.is_expanded() && entry.children().is_empty() {
+                entry.load_children(self.show_hidden)?;
+            }
+            entry.toggle_expanded();
+        }
+        Ok(())
+    }
+
+    /// Expand entry at path
+    pub fn expand(&mut self, path: &Path) -> anyhow::Result<()> {
+        if let Some(entry) = self.find_entry_mut(path) {
+            if entry.is_dir && entry.children().is_empty() {
+                entry.load_children(self.show_hidden)?;
+            }
+            entry.set_expanded(true);
+        }
+        Ok(())
+    }
+
+    /// Collapse entry at path
+    pub fn collapse(&mut self, path: &Path) {
+        if let Some(entry) = self.find_entry_mut(path) {
+            entry.set_expanded(false);
+        }
+    }
+
+    /// Reload tree from filesystem
+    pub fn reload(&mut self) -> anyhow::Result<()> {
+        let expanded_paths = self.collect_expanded_paths();
+        self.root.load_children(self.show_hidden)?;
+        self.restore_expanded(&expanded_paths)?;
+        Ok(())
+    }
+
+    /// Set show_hidden and reload
+    pub fn set_show_hidden(&mut self, show: bool) -> anyhow::Result<()> {
+        self.show_hidden = show;
+        self.reload()
+    }
+
+    /// Find entry by path (mutable)
+    fn find_entry_mut(&mut self, path: &Path) -> Option<&mut TreeEntry> {
+        Self::find_in_entry_mut(&mut self.root, path)
+    }
+
+    fn find_in_entry_mut<'a>(entry: &'a mut TreeEntry, path: &Path) -> Option<&'a mut TreeEntry> {
+        if entry.path == path {
+            return Some(entry);
+        }
+        for child in entry.children_mut() {
+            if let Some(found) = Self::find_in_entry_mut(child, path) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    /// Collect paths of all expanded entries
+    fn collect_expanded_paths(&self) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        self.collect_expanded_in(&self.root, &mut paths);
+        paths
+    }
+
+    fn collect_expanded_in(&self, entry: &TreeEntry, paths: &mut Vec<PathBuf>) {
+        if entry.is_expanded() {
+            paths.push(entry.path.clone());
+            for child in entry.children() {
+                self.collect_expanded_in(child, paths);
+            }
+        }
+    }
+
+    /// Restore expanded state from paths
+    fn restore_expanded(&mut self, paths: &[PathBuf]) -> anyhow::Result<()> {
+        for path in paths {
+            self.expand(path)?;
+        }
+        Ok(())
+    }
+}

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -87,12 +87,10 @@ impl TreeEntry {
             .collect();
 
         // Sort: directories first, then alphabetically
-        entries.sort_by(|a, b| {
-            match (a.is_dir, b.is_dir) {
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
-            }
+        entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
         });
 
         self.children = entries;

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,0 +1,101 @@
+//! Tree entry (node) definition
+
+use std::path::PathBuf;
+
+/// A single entry in the file tree
+#[derive(Debug, Clone)]
+pub struct TreeEntry {
+    /// Full path to the entry
+    pub path: PathBuf,
+    /// Display name
+    pub name: String,
+    /// Whether this is a directory
+    pub is_dir: bool,
+    /// Depth in the tree (0 = root)
+    pub depth: usize,
+    /// Whether directory is expanded
+    pub expanded: bool,
+    /// Child entries (directories only)
+    children: Vec<TreeEntry>,
+}
+
+impl TreeEntry {
+    /// Create a new tree entry
+    pub fn new(path: PathBuf, depth: usize) -> Self {
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.to_string_lossy().into_owned());
+        let is_dir = path.is_dir();
+
+        Self {
+            path,
+            name,
+            is_dir,
+            depth,
+            expanded: false,
+            children: Vec::new(),
+        }
+    }
+
+    /// Check if this entry is expanded
+    pub fn is_expanded(&self) -> bool {
+        self.expanded
+    }
+
+    /// Get children (immutable)
+    pub fn children(&self) -> &[TreeEntry] {
+        &self.children
+    }
+
+    /// Get children (mutable)
+    pub fn children_mut(&mut self) -> &mut Vec<TreeEntry> {
+        &mut self.children
+    }
+
+    /// Toggle expanded state
+    pub fn toggle_expanded(&mut self) {
+        if self.is_dir {
+            self.expanded = !self.expanded;
+        }
+    }
+
+    /// Set expanded state
+    pub fn set_expanded(&mut self, expanded: bool) {
+        if self.is_dir {
+            self.expanded = expanded;
+        }
+    }
+
+    /// Load children from filesystem
+    pub fn load_children(&mut self, show_hidden: bool) -> anyhow::Result<()> {
+        if !self.is_dir {
+            return Ok(());
+        }
+
+        self.children.clear();
+        let mut entries: Vec<_> = std::fs::read_dir(&self.path)?
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                if show_hidden {
+                    true
+                } else {
+                    !e.file_name().to_string_lossy().starts_with('.')
+                }
+            })
+            .map(|e| TreeEntry::new(e.path(), self.depth + 1))
+            .collect();
+
+        // Sort: directories first, then alphabetically
+        entries.sort_by(|a, b| {
+            match (a.is_dir, b.is_dir) {
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+            }
+        });
+
+        self.children = entries;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 完了: プロジェクト初期化、CI設定、モジュール構造作成

## Changes

### Project Setup
- `Cargo.toml` - 依存関係定義（ratatui, crossterm, anyhow, arboard, image）
- `.gitignore` - target/, Cargo.lock
- Binary name: `fv`

### CI/CD
- `.github/workflows/ci.yml`
  - cargo check
  - cargo fmt --check  
  - cargo clippy
  - cargo test

### Module Structure (myfileとは異なるモジュール階層)

```
src/
├── lib.rs
├── main.rs
├── core/           ← myfile: app.rs
│   ├── state.rs    (AppState)
│   └── mode.rs     (ViewMode)
├── tree/           ← myfile: file_tree.rs
│   ├── node.rs     (TreeEntry)
│   └── navigator.rs (TreeNavigator)
├── action/         ← myfile: file_ops.rs
│   ├── file.rs
│   └── clipboard.rs
├── render/         ← myfile: ui.rs
│   ├── tree.rs
│   ├── preview.rs
│   └── status.rs
├── handler/        ← myfile: input.rs
│   ├── key.rs
│   └── mouse.rs
└── integrate/      ← NEW (myfileにはない)
    ├── pick.rs
    └── callback.rs
```

### Implemented
- `core/state.rs` - AppState (focus_index, viewport_top, selected_paths)
- `core/mode.rs` - ViewMode with embedded state
- `tree/node.rs` - TreeEntry with load_children
- `tree/navigator.rs` - TreeNavigator with flatten
- `action/file.rs` - create, rename, delete, copy
- `action/clipboard.rs` - Clipboard (copy, cut)

### Stubs (TODO)
- render/* - UI rendering
- handler/* - Input handling
- integrate/* - --pick, --on-select

## Test Plan

- [ ] CI passes (check, fmt, clippy, test)