### PR TITLE
feat(integrate): Implement integrate module

### DIFF
--- a/src/integrate/callback.rs
+++ b/src/integrate/callback.rs
@@ -1,3 +1,184 @@
 //! Callback execution (--on-select option)
+//!
+//! Allows running external commands when files are selected.
+//! Supports placeholder expansion for paths.
 
-// TODO: Implement callback execution
+use std::path::Path;
+use std::process::Command;
+
+/// Placeholders for callback command expansion
+pub mod placeholder {
+    /// Full path: /path/to/file.txt
+    pub const PATH: &str = "{path}";
+    /// Directory: /path/to
+    pub const DIR: &str = "{dir}";
+    /// Filename with extension: file.txt
+    pub const NAME: &str = "{name}";
+    /// Filename without extension: file
+    pub const STEM: &str = "{stem}";
+    /// Extension only: txt
+    pub const EXT: &str = "{ext}";
+}
+
+/// Callback configuration
+#[derive(Debug, Clone)]
+pub struct Callback {
+    /// Command template with placeholders
+    command: String,
+    /// Whether to run in background (don't wait for completion)
+    background: bool,
+    /// Shell to use (default: sh -c)
+    shell: Option<String>,
+}
+
+impl Callback {
+    /// Create a new callback with the given command template
+    pub fn new(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            background: false,
+            shell: None,
+        }
+    }
+
+    /// Set whether to run in background
+    pub fn background(mut self, bg: bool) -> Self {
+        self.background = bg;
+        self
+    }
+
+    /// Set custom shell
+    pub fn shell(mut self, shell: impl Into<String>) -> Self {
+        self.shell = Some(shell.into());
+        self
+    }
+
+    /// Expand placeholders in command template
+    pub fn expand(&self, path: &Path) -> String {
+        let path_str = path.display().to_string();
+        let dir_str = path
+            .parent()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default();
+        let name_str = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let stem_str = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let ext_str = path
+            .extension()
+            .map(|e| e.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        self.command
+            .replace(placeholder::PATH, &shell_escape(&path_str))
+            .replace(placeholder::DIR, &shell_escape(&dir_str))
+            .replace(placeholder::NAME, &shell_escape(&name_str))
+            .replace(placeholder::STEM, &shell_escape(&stem_str))
+            .replace(placeholder::EXT, &shell_escape(&ext_str))
+    }
+
+    /// Execute callback for the given path
+    pub fn execute(&self, path: &Path) -> anyhow::Result<CallbackResult> {
+        let expanded = self.expand(path);
+
+        let shell = self.shell.as_deref().unwrap_or("sh");
+        let mut cmd = Command::new(shell);
+        cmd.arg("-c").arg(&expanded);
+
+        if self.background {
+            // Spawn and don't wait
+            let child = cmd.spawn()?;
+            Ok(CallbackResult::Spawned {
+                pid: child.id(),
+                command: expanded,
+            })
+        } else {
+            // Run and wait for result
+            let output = cmd.output()?;
+            Ok(CallbackResult::Completed {
+                success: output.status.success(),
+                exit_code: output.status.code(),
+                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            })
+        }
+    }
+
+    /// Execute callback for multiple paths
+    pub fn execute_many(&self, paths: &[&Path]) -> Vec<anyhow::Result<CallbackResult>> {
+        paths.iter().map(|p| self.execute(p)).collect()
+    }
+}
+
+/// Result of callback execution
+#[derive(Debug)]
+pub enum CallbackResult {
+    /// Command was spawned in background
+    Spawned { pid: u32, command: String },
+    /// Command completed
+    Completed {
+        success: bool,
+        exit_code: Option<i32>,
+        stdout: String,
+        stderr: String,
+    },
+}
+
+impl CallbackResult {
+    /// Check if execution was successful
+    pub fn is_success(&self) -> bool {
+        match self {
+            Self::Spawned { .. } => true,
+            Self::Completed { success, .. } => *success,
+        }
+    }
+}
+
+/// Escape a string for shell use
+fn shell_escape(s: &str) -> String {
+    // Simple escaping: wrap in single quotes, escape existing single quotes
+    if s.contains('\'') {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    } else {
+        format!("'{}'", s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_placeholder_expansion() {
+        let callback = Callback::new("echo {path} {name} {stem} {ext}");
+        let path = PathBuf::from("/home/user/document.txt");
+        let expanded = callback.expand(&path);
+
+        assert!(expanded.contains("'/home/user/document.txt'"));
+        assert!(expanded.contains("'document.txt'"));
+        assert!(expanded.contains("'document'"));
+        assert!(expanded.contains("'txt'"));
+    }
+
+    #[test]
+    fn test_shell_escape() {
+        assert_eq!(shell_escape("simple"), "'simple'");
+        assert_eq!(shell_escape("with space"), "'with space'");
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn test_callback_builder() {
+        let callback = Callback::new("test")
+            .background(true)
+            .shell("bash");
+
+        assert!(callback.background);
+        assert_eq!(callback.shell, Some("bash".to_string()));
+    }
+}

--- a/src/integrate/callback.rs
+++ b/src/integrate/callback.rs
@@ -174,9 +174,7 @@ mod tests {
 
     #[test]
     fn test_callback_builder() {
-        let callback = Callback::new("test")
-            .background(true)
-            .shell("bash");
+        let callback = Callback::new("test").background(true).shell("bash");
 
         assert!(callback.background);
         assert_eq!(callback.shell, Some("bash".to_string()));

--- a/src/integrate/mod.rs
+++ b/src/integrate/mod.rs
@@ -1,4 +1,11 @@
 //! Integrate module - External integration features
+//!
+//! Provides integration with external tools:
+//! - Pick mode: Use fileview as a file picker (--pick)
+//! - Callback: Run commands on file selection (--on-select)
 
 pub mod callback;
 pub mod pick;
+
+pub use callback::{Callback, CallbackResult};
+pub use pick::{exit_code, output_paths, OutputFormat, PickResult};

--- a/src/integrate/pick.rs
+++ b/src/integrate/pick.rs
@@ -1,3 +1,159 @@
 //! Pick mode (--pick option)
+//!
+//! Allows external tools to use fileview as a file picker.
+//! Selected path(s) are output to stdout when user confirms selection.
 
-// TODO: Implement pick mode
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+/// Exit codes for pick mode
+pub mod exit_code {
+    /// User selected file(s) successfully
+    pub const SUCCESS: i32 = 0;
+    /// User cancelled selection
+    pub const CANCELLED: i32 = 1;
+    /// Error occurred
+    pub const ERROR: i32 = 2;
+}
+
+/// Output format for picked paths
+#[derive(Debug, Clone, Copy, Default)]
+pub enum OutputFormat {
+    /// One path per line (default)
+    #[default]
+    Lines,
+    /// Null-separated paths (for xargs -0)
+    NullSeparated,
+    /// JSON array
+    Json,
+}
+
+impl OutputFormat {
+    /// Parse from string argument
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "lines" | "line" => Some(Self::Lines),
+            "null" | "nul" | "0" => Some(Self::NullSeparated),
+            "json" => Some(Self::Json),
+            _ => None,
+        }
+    }
+}
+
+/// Output selected paths to stdout
+pub fn output_paths(paths: &[PathBuf], format: OutputFormat) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+
+    match format {
+        OutputFormat::Lines => {
+            for path in paths {
+                writeln!(handle, "{}", path.display())?;
+            }
+        }
+        OutputFormat::NullSeparated => {
+            for (i, path) in paths.iter().enumerate() {
+                if i > 0 {
+                    write!(handle, "\0")?;
+                }
+                write!(handle, "{}", path.display())?;
+            }
+            // Final null for xargs compatibility
+            if !paths.is_empty() {
+                write!(handle, "\0")?;
+            }
+        }
+        OutputFormat::Json => {
+            let json_paths: Vec<String> =
+                paths.iter().map(|p| p.display().to_string()).collect();
+            writeln!(handle, "{}", serde_json_mini(&json_paths))?;
+        }
+    }
+
+    handle.flush()?;
+    Ok(())
+}
+
+/// Minimal JSON array serialization (no serde dependency)
+fn serde_json_mini(paths: &[String]) -> String {
+    let escaped: Vec<String> = paths
+        .iter()
+        .map(|p| {
+            let escaped = p
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', "\\n")
+                .replace('\r', "\\r")
+                .replace('\t', "\\t");
+            format!("\"{}\"", escaped)
+        })
+        .collect();
+
+    format!("[{}]", escaped.join(","))
+}
+
+/// Pick mode result
+#[derive(Debug)]
+pub enum PickResult {
+    /// User selected paths
+    Selected(Vec<PathBuf>),
+    /// User cancelled
+    Cancelled,
+}
+
+impl PickResult {
+    /// Get exit code for this result
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::Selected(_) => exit_code::SUCCESS,
+            Self::Cancelled => exit_code::CANCELLED,
+        }
+    }
+
+    /// Output result to stdout if paths were selected
+    pub fn output(&self, format: OutputFormat) -> io::Result<i32> {
+        match self {
+            Self::Selected(paths) => {
+                output_paths(paths, format)?;
+                Ok(exit_code::SUCCESS)
+            }
+            Self::Cancelled => Ok(exit_code::CANCELLED),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_json_escape() {
+        let paths = vec![
+            String::from("/path/to/file"),
+            String::from("/path/with\"quote"),
+            String::from("/path/with\\backslash"),
+        ];
+        let json = serde_json_mini(&paths);
+        assert!(json.starts_with('['));
+        assert!(json.ends_with(']'));
+        assert!(json.contains("\\\""));
+        assert!(json.contains("\\\\"));
+    }
+
+    #[test]
+    fn test_output_format_parse() {
+        assert!(matches!(
+            OutputFormat::from_str("lines"),
+            Some(OutputFormat::Lines)
+        ));
+        assert!(matches!(
+            OutputFormat::from_str("null"),
+            Some(OutputFormat::NullSeparated)
+        ));
+        assert!(matches!(
+            OutputFormat::from_str("json"),
+            Some(OutputFormat::Json)
+        ));
+        assert!(OutputFormat::from_str("invalid").is_none());
+    }
+}

--- a/src/integrate/pick.rs
+++ b/src/integrate/pick.rs
@@ -5,6 +5,7 @@
 
 use std::io::{self, Write};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 /// Exit codes for pick mode
 pub mod exit_code {
@@ -28,14 +29,15 @@ pub enum OutputFormat {
     Json,
 }
 
-impl OutputFormat {
-    /// Parse from string argument
-    pub fn from_str(s: &str) -> Option<Self> {
+impl FromStr for OutputFormat {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "lines" | "line" => Some(Self::Lines),
-            "null" | "nul" | "0" => Some(Self::NullSeparated),
-            "json" => Some(Self::Json),
-            _ => None,
+            "lines" | "line" => Ok(Self::Lines),
+            "null" | "nul" | "0" => Ok(Self::NullSeparated),
+            "json" => Ok(Self::Json),
+            _ => Err(()),
         }
     }
 }
@@ -64,8 +66,7 @@ pub fn output_paths(paths: &[PathBuf], format: OutputFormat) -> io::Result<()> {
             }
         }
         OutputFormat::Json => {
-            let json_paths: Vec<String> =
-                paths.iter().map(|p| p.display().to_string()).collect();
+            let json_paths: Vec<String> = paths.iter().map(|p| p.display().to_string()).collect();
             writeln!(handle, "{}", serde_json_mini(&json_paths))?;
         }
     }
@@ -144,16 +145,16 @@ mod tests {
     fn test_output_format_parse() {
         assert!(matches!(
             OutputFormat::from_str("lines"),
-            Some(OutputFormat::Lines)
+            Ok(OutputFormat::Lines)
         ));
         assert!(matches!(
             OutputFormat::from_str("null"),
-            Some(OutputFormat::NullSeparated)
+            Ok(OutputFormat::NullSeparated)
         ));
         assert!(matches!(
             OutputFormat::from_str("json"),
-            Some(OutputFormat::Json)
+            Ok(OutputFormat::Json)
         ));
-        assert!(OutputFormat::from_str("invalid").is_none());
+        assert!(OutputFormat::from_str("invalid").is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Implement `integrate/pick.rs`: Pick mode for file selection
  - OutputFormat enum (lines, null-separated, json)
  - Exit codes for success/cancelled/error
  - Path output to stdout with format options
- Implement `integrate/callback.rs`: Callback execution
  - Placeholder expansion: {path}, {dir}, {name}, {stem}, {ext}
  - Background execution support
  - Shell escape for safe command execution

## Phase 7 Progress
- [x] 7.1 integrate/pick.rs - --pick mode
- [x] 7.2 integrate/callback.rs - --on-select callback

## Test plan
- [ ] CI passes (check, clippy, fmt, test)
- [ ] Unit tests for JSON escape and placeholder expansion