### PR TITLE
fix: Load preview data in fullscreen mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -229,8 +229,9 @@ fn run_app(
         // Get focused entry path
         let focused_path = snapshots.get(state.focus_index).map(|e| e.path.clone());
 
-        // Update preview if needed
-        if state.preview_visible {
+        // Update preview if needed (side panel or fullscreen mode)
+        let needs_preview = state.preview_visible || matches!(state.mode, ViewMode::Preview { .. });
+        if needs_preview {
             if let Some(path) = &focused_path {
                 if path.is_dir() {
                     // Load directory info


### PR DESCRIPTION
## Summary
- `o`キーでフルスクリーンプレビューを開いた時にもプレビューデータを読み込むように修正

## 問題
プレビューデータは `state.preview_visible` が true の時のみ読み込まれていた。
`o`キーは `ViewMode::Preview` を設定するが `preview_visible` は変更しないため、
サイドパネル(`P`)を先に開いていないとフルスクリーンプレビューに何も表示されなかった。

## 修正内容
```rust
// Before
if state.preview_visible {

// After
let needs_preview = state.preview_visible || matches!(state.mode, ViewMode::Preview { .. });
if needs_preview {
```

## Test plan
- [x] サイドパネルを開かずに`o`を押してもプレビューが表示される
- [x] `P`でサイドパネルを開いてから`o`でも正常に動作する