### PR TITLE
fix: Enable bracketed paste for macOS file drop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,10 @@ use std::time::Duration;
 
 use crossterm::{
     cursor,
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event},
+    event::{
+        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event,
+    },
     execute,
     terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -161,7 +164,12 @@ fn run() -> anyhow::Result<i32> {
     // Initialize terminal
     terminal::enable_raw_mode()?;
     let mut stdout = stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste
+    )?;
 
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
@@ -175,6 +183,7 @@ fn run() -> anyhow::Result<i32> {
         terminal.backend_mut(),
         LeaveAlternateScreen,
         DisableMouseCapture,
+        DisableBracketedPaste,
         cursor::Show
     )?;
 


### PR DESCRIPTION
## Summary
- Enable `EnableBracketedPaste` for terminal setup
- Fixes issue where dropping files on macOS triggers Search mode instead of file copy

## Problem
On macOS, file drop sends path as individual key events:
1. Path `/Users/...` starts with `/`
2. First `/` triggers `StartSearch`
3. Rest of path typed into search query
4. App becomes unresponsive in Search mode

## Solution
Enable bracketed paste so dropped content is received as `Event::Paste`, which is properly handled by existing drop detection logic.