### PR TITLE
chore: Release v0.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]


### PR DESCRIPTION
## Release v0.4.3

### Changes
- **fix**: Enable bracketed paste for macOS file drop (#20)
- **feat**: Improve Windows file drop support (#21)

### What's Fixed
- File drop on macOS no longer triggers Search mode
- Windows `file:///C:/path` URLs are correctly parsed
- URL-encoded paths (spaces, special chars) work correctly