### PR TITLE
fix: Support drag-and-drop via Key events (Ghostty compatibility)

### DIFF
--- a/examples/debug_events.rs
+++ b/examples/debug_events.rs
@@ -1,0 +1,73 @@
+//! Debug tool to see what events are sent when dragging files
+//!
+//! Run with: cargo run --example debug_events
+//! Then drag a file from Finder to the terminal window.
+//! Press 'q' to quit.
+
+use std::io::stdout;
+use std::time::Duration;
+
+use crossterm::{
+    event::{
+        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event,
+    },
+    execute,
+    terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
+};
+
+fn main() -> anyhow::Result<()> {
+    terminal::enable_raw_mode()?;
+    let mut stdout = stdout();
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste
+    )?;
+
+    println!("Drag a file from Finder to this window.");
+    println!("Press 'q' to quit.\n");
+
+    loop {
+        if event::poll(Duration::from_millis(100))? {
+            let evt = event::read()?;
+
+            match &evt {
+                Event::Key(key) => {
+                    println!("Key: {:?}", key);
+                    if key.code == crossterm::event::KeyCode::Char('q') {
+                        break;
+                    }
+                }
+                Event::Mouse(mouse) => {
+                    println!("Mouse: {:?}", mouse);
+                }
+                Event::Paste(text) => {
+                    println!("Paste: {:?}", text);
+                    println!("  Length: {} chars", text.len());
+                    println!("  Lines: {:?}", text.lines().collect::<Vec<_>>());
+                }
+                Event::Resize(w, h) => {
+                    println!("Resize: {}x{}", w, h);
+                }
+                Event::FocusGained => {
+                    println!("FocusGained");
+                }
+                Event::FocusLost => {
+                    println!("FocusLost");
+                }
+            }
+        }
+    }
+
+    terminal::disable_raw_mode()?;
+    execute!(
+        stdout,
+        LeaveAlternateScreen,
+        DisableMouseCapture,
+        DisableBracketedPaste
+    )?;
+
+    Ok(())
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1170,3 +1170,188 @@ mod file_operations_tests {
         assert!(!dir_path.exists());
     }
 }
+
+// =============================================================================
+// Drag and Drop Tests
+// =============================================================================
+
+mod drag_and_drop_tests {
+    use fileview::handler::mouse::DropDetector;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_drop_detector_with_real_file() {
+        let temp = TempDir::new().unwrap();
+        let file_path = temp.path().join("test_file.txt");
+        fs::write(&file_path, "test content").unwrap();
+
+        let mut detector = DropDetector::new();
+        detector.push_char('/'); // Start path
+
+        // Simulate rapid input of file path
+        let path_str = file_path.display().to_string();
+        for c in path_str.chars().skip(1) {
+            detector.push_char(c);
+        }
+
+        let paths = detector.extract_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], file_path);
+    }
+
+    #[test]
+    fn test_drop_detector_with_real_directory() {
+        let temp = TempDir::new().unwrap();
+        let dir_path = temp.path().join("test_dir");
+        fs::create_dir(&dir_path).unwrap();
+
+        let mut detector = DropDetector::new();
+        let path_str = dir_path.display().to_string();
+        for c in path_str.chars() {
+            detector.push_char(c);
+        }
+
+        let paths = detector.extract_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], dir_path);
+    }
+
+    #[test]
+    fn test_drop_detector_file_url_format() {
+        let temp = TempDir::new().unwrap();
+        let file_path = temp.path().join("test.txt");
+        fs::write(&file_path, "content").unwrap();
+
+        let mut detector = DropDetector::new();
+        // Simulate file:// URL format
+        let url = format!("file://{}", file_path.display());
+        for c in url.chars() {
+            detector.push_char(c);
+        }
+
+        let paths = detector.extract_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], file_path);
+    }
+
+    #[test]
+    fn test_drop_detector_url_encoded_spaces() {
+        let temp = TempDir::new().unwrap();
+        let file_path = temp.path().join("file with spaces.txt");
+        fs::write(&file_path, "content").unwrap();
+
+        let mut detector = DropDetector::new();
+        // Simulate URL-encoded path with %20 for spaces
+        let path_str = file_path.display().to_string().replace(' ', "%20");
+        for c in path_str.chars() {
+            detector.push_char(c);
+        }
+
+        let paths = detector.extract_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], file_path);
+    }
+
+    #[test]
+    fn test_drop_detector_backslash_escaped_spaces() {
+        let temp = TempDir::new().unwrap();
+        let file_path = temp.path().join("file with spaces.txt");
+        fs::write(&file_path, "content").unwrap();
+
+        let mut detector = DropDetector::new();
+        // Simulate backslash-escaped path (macOS terminal style)
+        let path_str = file_path.display().to_string().replace(' ', "\\ ");
+        for c in path_str.chars() {
+            detector.push_char(c);
+        }
+
+        let paths = detector.extract_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], file_path);
+    }
+
+    #[test]
+    fn test_drop_detector_multiple_files() {
+        let temp = TempDir::new().unwrap();
+        let file1 = temp.path().join("file1.txt");
+        let file2 = temp.path().join("file2.txt");
+        fs::write(&file1, "content1").unwrap();
+        fs::write(&file2, "content2").unwrap();
+
+        let mut detector = DropDetector::new();
+        // Simulate multiple paths separated by newline
+        let paths_str = format!("{}\n{}", file1.display(), file2.display());
+        for c in paths_str.chars() {
+            detector.push_char(c);
+        }
+
+        let paths = detector.extract_paths();
+        assert_eq!(paths.len(), 2);
+        assert!(paths.contains(&file1));
+        assert!(paths.contains(&file2));
+    }
+
+    #[test]
+    fn test_drop_detector_nonexistent_path_filtered() {
+        let mut detector = DropDetector::new();
+        // Path that doesn't exist should be filtered out
+        let fake_path = "/nonexistent/path/to/file.txt";
+        for c in fake_path.chars() {
+            detector.push_char(c);
+        }
+
+        let paths = detector.extract_paths();
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_drop_detector_mixed_existing_nonexisting() {
+        let temp = TempDir::new().unwrap();
+        let existing = temp.path().join("existing.txt");
+        fs::write(&existing, "content").unwrap();
+
+        let mut detector = DropDetector::new();
+        // Mix of existing and non-existing paths
+        let paths_str = format!("{}\n/nonexistent/path.txt", existing.display());
+        for c in paths_str.chars() {
+            detector.push_char(c);
+        }
+
+        let paths = detector.extract_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], existing);
+    }
+
+    #[test]
+    fn test_drop_detector_quoted_path_with_spaces() {
+        let temp = TempDir::new().unwrap();
+        let file_path = temp.path().join("file with spaces.txt");
+        fs::write(&file_path, "content").unwrap();
+
+        let mut detector = DropDetector::new();
+        // Simulate quoted path
+        let quoted = format!("\"{}\"", file_path.display());
+        for c in quoted.chars() {
+            detector.push_char(c);
+        }
+
+        let paths = detector.extract_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], file_path);
+    }
+
+    #[test]
+    fn test_drop_detector_clear() {
+        let mut detector = DropDetector::new();
+        detector.push_char('/');
+        detector.push_char('t');
+        detector.push_char('e');
+        detector.push_char('s');
+        detector.push_char('t');
+
+        assert!(!detector.is_empty());
+        detector.clear();
+        assert!(detector.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Fix drag-and-drop not working on Ghostty terminal
- Ghostty sends file paths as individual `Event::Key` instead of `Event::Paste`
- Implement timeout-based drop detection (similar to myfile project)

## Changes

- **Timeout-based detection**: Buffer rapid key inputs (50ms threshold), process after 100ms timeout
- **Path normalization**: Handle backslash escapes, URL encoding, quotes
- **Fallback**: If `/` prefix doesn't resolve to valid path, start search mode
- **Tests**: Add 10 integration tests for drag-and-drop scenarios
- **Debug tool**: Add `examples/debug_events.rs` for troubleshooting terminal events

## Test plan

- [x] Run `cargo test` - all 61 integration tests pass
- [x] Manual test: drag image from Finder to fileview on Ghostty
- [x] Verify normal key operations still work (e.g., `/` for search)