### PR TITLE
refactor: Rename DropDetector to PathBuffer with cleaner API

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -4,4 +4,4 @@ pub mod key;
 pub mod mouse;
 
 pub use key::{create_delete_targets, handle_key_event, update_input_buffer, KeyAction};
-pub use mouse::{handle_mouse_event, ClickDetector, DropDetector, MouseAction};
+pub use mouse::{handle_mouse_event, ClickDetector, MouseAction, PathBuffer};


### PR DESCRIPTION
## Summary

- Refactor drag-and-drop detection to use fileview-native naming and cleaner API
- This replaces the previous implementation with a more minimal, idiomatic design

## Changes

| Item | Before | After |
|------|--------|-------|
| Class | `DropDetector` | `PathBuffer` |
| Methods | `push_char`, `check_timeout`, `extract_paths`, `take_buffer` | `push`, `is_ready`, `take_paths`, `take_raw` |
| Lines | 454 | **355** (22% reduction) |

### Improvements

- Use constants for timing thresholds (`RAPID_INPUT_THRESHOLD_MS`, `INPUT_TIMEOUT_MS`)
- Extract helper functions: `normalize_shell_path`, `parse_paths`, `to_path`
- Cleaner API with more intuitive method names
- All tests updated and passing (61 integration + 55 unit)

## Test plan

- [x] `cargo test` - all tests pass
- [x] Manual test: drag file from Finder on Ghostty