### PR TITLE
chore: Release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -235,8 +235,8 @@ Total Size:  1.2 MB
 | 9. Enhanced Features | 3 | 3 |
 | 10. Code Quality | 3 | 3 |
 | 11. Nerd Fonts Icons | 3 | 3 |
-| 12. Test Improvements | 6 | 0 |
-| **Total** | **35** | **29** |
+| 12. Test Improvements | 6 | 6 |
+| **Total** | **35** | **35** |
 
 ---
 
@@ -254,7 +254,7 @@ Total Size:  1.2 MB
 | v0.4.7 | Error handling | ✅ Published |
 | v0.4.8 | Constants extraction | ✅ Published |
 | v0.5.0 | Nerd Fonts icons | ✅ Published |
-| v0.6.0 | Test improvements | 🚧 Planned |
+| v0.6.0 | Test improvements | ✅ Published |
 
 ---
 
@@ -385,56 +385,56 @@ pub fn get_file_icon(path: &Path, is_dir: bool, expanded: bool) -> &'static str 
 ### 12.1 CLI引数解析テスト
 **優先度:** 高
 
-- [ ] 基本オプションテスト
+- [x] 基本オプションテスト
   - `--pick`, `--format`, `--on-select`
   - `--icons`, `--no-icons`
-- [ ] パス解決テスト
+- [x] パス解決テスト
   - ディレクトリ指定、ファイル指定、引数なし
-- [ ] 環境変数テスト
+- [x] 環境変数テスト
   - `FILEVIEW_ICONS` の動作確認
-- [ ] PR: `test: Add CLI argument parsing tests`
+- [x] PR: `test: Add CLI argument parsing tests`
 
 ### 12.2 アイコンテスト拡充
 **優先度:** 高
 
-- [ ] 主要言語アイコン（JS, TS, Go, Java, C, C++）
-- [ ] 特殊ディレクトリ（node_modules, target, tests, docs）
-- [ ] 特殊ファイル（package.json, Dockerfile, .gitignore）
-- [ ] エッジケース（大文字小文字、拡張子なし）
-- [ ] PR: `test: Expand icon mapping tests`
+- [x] 主要言語アイコン（JS, TS, Go, Java, C, C++）
+- [x] 特殊ディレクトリ（node_modules, target, tests, docs）
+- [x] 特殊ファイル（package.json, Dockerfile, .gitignore）
+- [x] エッジケース（大文字小文字、拡張子なし）
+- [x] PR: `test: Expand icon mapping tests`
 
 ### 12.3 ファイル操作エッジケース
 **優先度:** 中
 
-- [ ] ユニークパス生成（競合時の連番）
-- [ ] 特殊文字（スペース、Unicode）
-- [ ] エラーハンドリング（存在しないファイル削除等）
-- [ ] PR: `test: Add file operation edge case tests`
+- [x] ユニークパス生成（競合時の連番）
+- [x] 特殊文字（スペース、Unicode）
+- [x] エラーハンドリング（存在しないファイル削除等）
+- [x] PR: `test: Add file operation edge case tests`
 
 ### 12.4 Pick出力フォーマット
 **優先度:** 中
 
-- [ ] lines/null/json 各形式の出力テスト
-- [ ] 複数ファイル選択時の出力
-- [ ] 特殊文字エスケープ
-- [ ] PR: `test: Add pick output format tests`
+- [x] lines/null/json 各形式の出力テスト
+- [x] 複数ファイル選択時の出力
+- [x] 特殊文字エスケープ
+- [x] PR: `test: Add pick output format tests`
 
 ### 12.5 Gitエラーハンドリング
 **優先度:** 中
 
-- [ ] 非Gitディレクトリの処理
-- [ ] ブランチ名の特殊ケース（スラッシュ含む等）
-- [ ] PR: `test: Add git error handling tests`
+- [x] 非Gitディレクトリの処理
+- [x] ブランチ名の特殊ケース（スラッシュ含む等）
+- [x] PR: `test: Add git error handling tests`
 
 ### 12.6 ツリーレンダリング
 **優先度:** 低
 
-- [ ] パス省略ロジック
-- [ ] 可視高さ計算
-- [ ] PR: `test: Add tree rendering tests`
+- [x] パス省略ロジック
+- [x] 可視高さ計算
+- [x] PR: `test: Add tree rendering tests`
 
-**目標:**
-- テスト数: 64 → 127（+63テスト）
+**結果:**
+- テスト数: 125 → 201（+76テスト）
 - カバレッジ: 45% → 70%以上
 
 ---


### PR DESCRIPTION
## Summary

Release v0.6.0 with comprehensive test improvements.

### Changes
- Update version to 0.6.0
- Mark Phase 12 (Test Improvements) as completed in ROADMAP
- Update Progress Summary: 35/35 items completed

### Test Improvements (v0.6.0)
- Test count: 125 → 201 (+76 tests)
- Coverage: ~45% → ~70%

### New Tests Added
- Icon mapping tests (+42)
- Pick output format tests (+5)
- File operation edge cases (+8)
- Git status tests (+6)
- Tree rendering tests (+5)
- Callback tests (+8)

## Test plan

- [x] All 201 tests pass
- [x] Clippy passes