### PR TITLE
test: add sequence tests for multi-step workflows (Phase 13.3)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -236,8 +236,8 @@ Total Size:  1.2 MB
 | 10. Code Quality | 3 | 3 |
 | 11. Nerd Fonts Icons | 3 | 3 |
 | 12. Test Improvements | 6 | 6 |
-| 13. E2E / Behavioral Tests | 4 | 2 |
-| **Total** | **39** | **37** |
+| 13. E2E / Behavioral Tests | 4 | 3 |
+| **Total** | **39** | **38** |
 
 ---
 
@@ -482,14 +482,17 @@ v0.6.1で修正したバグ（プレビュースクロール、Enterキー動作
 ### 13.3 シーケンステスト
 **優先度:** 中
 
-- [ ] 操作シーケンスのテスト
+- [x] 操作シーケンスのテスト
   - `j` → `j` → `o` → `j` → `j` → `q` (ナビゲーション+プレビュー)
   - `P` → `Enter` (サイドプレビュー→閉じる)
   - `/` → `test` → `Enter` → `n` (検索シーケンス)
-- [ ] 複合操作のテスト
+- [x] 複合操作のテスト
   - 選択 → コピー → 移動 → ペースト
   - リネーム → キャンセル → リネーム → 確定
-- [ ] PR: `test: Add operation sequence tests`
+  - 作成 → 削除
+  - 展開 → ナビゲート → 全折りたたみ
+  - カット → ペースト（移動）
+- [x] PR: `test: Add operation sequence tests`
 
 ### 13.4 エッジケーステスト
 **優先度:** 中


### PR DESCRIPTION
## Summary
Phase 13.3: シーケンステスト（複数ステップのワークフロー検証）

### 追加テスト（8件）

| テスト | シーケンス | 検証内容 |
|--------|-----------|---------|
| `test_sequence_navigation_with_preview` | j→j→o→scroll→Cancel | ナビゲーション+プレビュー |
| `test_sequence_side_preview_toggle_enter` | P→Enter | サイドプレビュー閉じる（v0.6.1修正） |
| `test_sequence_search_workflow` | /→type→Enter→n | 検索ワークフロー |
| `test_sequence_copy_paste_workflow` | mark→y→navigate→p | コピー&ペースト |
| `test_sequence_rename_cancel_rename_confirm` | r→Esc→r→Enter | リネームキャンセル→再試行 |
| `test_sequence_expand_navigate_collapse_all` | l→navigate→H | 展開→全折りたたみ |
| `test_sequence_create_delete_workflow` | a→name→D→y | 作成→削除 |
| `test_sequence_cut_paste_multiple` | mark→d→navigate→p | カット&ペースト（移動） |

### ROADMAPの更新
- Phase 13.3 ✅ 完了

## Test plan
- [x] `cargo test` - 全238テストがパス（+8）
- [x] `cargo clippy` - 警告なし
- [x] `cargo fmt` - フォーマット済み