### PR TITLE
fix: Image preview not displaying in VS Code terminal

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -18,7 +18,54 @@ pub use tree::{render_tree, visible_height};
 /// Create an image picker for protocol detection
 ///
 /// This should be called BEFORE entering alternate screen mode.
-/// Returns None if terminal capability detection fails.
+/// Tries to query terminal capabilities first, falls back to halfblock rendering.
+///
+/// Set environment variable `FILEVIEW_IMAGE_PROTOCOL` to control behavior:
+/// - `auto` (default): Auto-detect terminal protocol
+/// - `halfblocks`: Force halfblock rendering (most compatible)
+/// - `sixel`, `kitty`, `iterm2`: Force specific protocol
 pub fn create_image_picker() -> Option<Picker> {
-    Picker::from_query_stdio().ok()
+    use ratatui_image::picker::ProtocolType;
+
+    // Check for environment variable override
+    if let Ok(protocol) = std::env::var("FILEVIEW_IMAGE_PROTOCOL") {
+        match protocol.to_lowercase().as_str() {
+            "halfblocks" | "half" => return Some(Picker::halfblocks()),
+            "sixel" => {
+                let mut picker = Picker::halfblocks();
+                picker.set_protocol_type(ProtocolType::Sixel);
+                return Some(picker);
+            }
+            "kitty" => {
+                let mut picker = Picker::halfblocks();
+                picker.set_protocol_type(ProtocolType::Kitty);
+                return Some(picker);
+            }
+            "iterm2" | "iterm" => {
+                let mut picker = Picker::halfblocks();
+                picker.set_protocol_type(ProtocolType::Iterm2);
+                return Some(picker);
+            }
+            _ => {} // "auto" or unknown, continue with auto-detection
+        }
+    }
+
+    // VS Code terminal doesn't properly support advanced image protocols
+    // (ratatui-image detects it as iTerm2 compatible, but it doesn't work)
+    if is_vscode_terminal() {
+        return Some(Picker::halfblocks());
+    }
+
+    // Try to query terminal for image protocol support (Sixel/Kitty/iTerm2)
+    Picker::from_query_stdio().ok().or_else(|| {
+        // Fallback: use halfblock rendering
+        Some(Picker::halfblocks())
+    })
+}
+
+/// Check if running in VS Code integrated terminal
+fn is_vscode_terminal() -> bool {
+    std::env::var("TERM_PROGRAM")
+        .map(|v| v.to_lowercase().contains("vscode"))
+        .unwrap_or(false)
 }

--- a/src/render/preview.rs
+++ b/src/render/preview.rs
@@ -241,7 +241,9 @@ pub fn render_image_preview(
     frame.render_widget(block, area);
 
     // Render image using ratatui-image's StatefulImage widget
-    let image_widget = StatefulImage::default().resize(Resize::Fit(None));
+    // Use Resize::Scale to ensure the image fills the entire preview area
+    // (Resize::Fit doesn't scale up images smaller than the area in cell-space)
+    let image_widget = StatefulImage::default().resize(Resize::Scale(None));
     frame.render_stateful_widget(image_widget, inner_area, &mut img.protocol);
 }
 


### PR DESCRIPTION
## Summary
- Fix image preview not displaying (completely dark) in VS Code terminal
- Add automatic VS Code detection with halfblocks fallback
- Add `FILEVIEW_IMAGE_PROTOCOL` environment variable for manual protocol control

## Root Causes
1. `Resize::Fit` didn't scale up images that were smaller than the render area (in cell-space calculated with font_size)
2. ratatui-image's `from_query_stdio()` incorrectly detected VS Code as supporting iTerm2 protocol, but VS Code doesn't actually support it

## Changes
- `src/render/preview.rs`: Change `Resize::Fit` to `Resize::Scale` to ensure images fill the preview area
- `src/render/mod.rs`: Auto-detect VS Code terminal and use halfblocks rendering; add env var override

## Environment Variable
`FILEVIEW_IMAGE_PROTOCOL` can be set to:
- `auto` (default): Auto-detect terminal capabilities
- `halfblocks`: Force Unicode halfblock rendering (most compatible)
- `sixel`, `kitty`, `iterm2`: Force specific protocol

## Test plan
- [x] Run `cargo run` in VS Code terminal and verify image preview displays
- [x] Verify test_color.png and other images display correctly
- [x] All 145 tests pass