### PR TITLE
feat: Add terminal brand detection for optimized image protocols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "png"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1779,7 @@ dependencies = [
  "base64-simd",
  "icy_sixel",
  "image",
+ "pkg-config",
  "rand 0.8.5",
  "ratatui",
  "rustix 0.38.44",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ categories = ["command-line-utilities"]
 name = "fv"
 path = "src/main.rs"
 
+[features]
+default = []
+# Enable Chafa fallback for better image quality on terminals without native protocol support
+# Requires libchafa (>= 1.8.0) to be installed: brew install chafa (macOS) or apt install libchafa-dev (Linux)
+chafa = ["ratatui-image/chafa-dyn"]
+
 [dependencies]
 ratatui = "0.30"
 crossterm = "0.29"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ English | [日本語](README_ja.md)
 - Multi-select support for batch operations
 - **Preview panel** with support for:
   - Text files (syntax highlighting by extension)
-  - Images (half-block rendering)
+  - Images (Kitty/iTerm2/Sixel protocols with auto-detection)
   - Directories (file count, size statistics)
   - Binary files (hex dump view)
 - Copy/cut/paste with internal clipboard
@@ -40,6 +40,26 @@ When inside a git repository, files are color-coded by their status:
 
 The current branch name is displayed in the status bar.
 
+## Image Preview
+
+FileView automatically detects your terminal and selects the optimal image protocol:
+
+| Terminal | Protocol | Quality |
+|----------|----------|---------|
+| Kitty | Kitty Graphics | Highest |
+| Ghostty | Kitty Graphics | Highest |
+| Konsole | Kitty Graphics | Highest |
+| iTerm2 | iTerm2 Inline | Highest |
+| WezTerm | iTerm2 Inline | Highest |
+| Warp | iTerm2 Inline | Highest |
+| Foot | Sixel | Good |
+| Windows Terminal | Sixel | Good |
+| VS Code | Halfblocks | Basic |
+| Alacritty | Halfblocks | Basic |
+| Other | Auto-detect | Varies |
+
+Override with `FILEVIEW_IMAGE_PROTOCOL` environment variable (see below).
+
 ## Installation
 
 ### From crates.io (Recommended)
@@ -48,12 +68,31 @@ The current branch name is displayed in the status bar.
 cargo install fileview
 ```
 
+### With Chafa support (optional)
+
+For better image quality on terminals without native image protocol support:
+
+```bash
+# Install libchafa first
+# macOS:
+brew install chafa
+
+# Ubuntu/Debian:
+sudo apt install libchafa-dev
+
+# Then install with chafa feature
+cargo install fileview --features chafa
+```
+
 ### From source
 
 ```bash
 git clone https://github.com/Hiro-Chiba/fileview.git
 cd fileview
 cargo install --path .
+
+# Or with chafa:
+cargo install --path . --features chafa
 ```
 
 ### Requirements
@@ -177,6 +216,7 @@ When the side preview panel is open, press `Tab` to switch focus:
 | Variable | Description |
 |----------|-------------|
 | `FILEVIEW_ICONS=0` | Disable icons by default |
+| `FILEVIEW_IMAGE_PROTOCOL` | Force image protocol: `auto`, `halfblocks`, `chafa`, `sixel`, `kitty`, `iterm2` |
 
 ### Placeholders for `--on-select`
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ FileView automatically detects your terminal and selects the optimal image proto
 | Warp | iTerm2 Inline | Highest |
 | Foot | Sixel | Good |
 | Windows Terminal | Sixel | Good |
-| VS Code | Halfblocks | Basic |
+| VS Code | iTerm2 Inline | Highest |
 | Alacritty | Halfblocks | Basic |
 | Other | Auto-detect | Varies |
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ FileView automatically detects your terminal and selects the optimal image proto
 | Warp | iTerm2 Inline | Highest |
 | Foot | Sixel | Good |
 | Windows Terminal | Sixel | Good |
-| VS Code | iTerm2 Inline | Highest |
+| VS Code | Halfblocks | Basic |
 | Alacritty | Halfblocks | Basic |
 | Other | Auto-detect | Varies |
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -54,7 +54,7 @@ FileViewはターミナルを自動検出し、最適な画像プロトコルを
 | Warp | iTerm2 Inline | 最高 |
 | Foot | Sixel | 良好 |
 | Windows Terminal | Sixel | 良好 |
-| VS Code | iTerm2 Inline | 最高 |
+| VS Code | Halfblocks | 基本 |
 | Alacritty | Halfblocks | 基本 |
 | その他 | 自動検出 | 可変 |
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -54,7 +54,7 @@ FileViewはターミナルを自動検出し、最適な画像プロトコルを
 | Warp | iTerm2 Inline | 最高 |
 | Foot | Sixel | 良好 |
 | Windows Terminal | Sixel | 良好 |
-| VS Code | Halfblocks | 基本 |
+| VS Code | iTerm2 Inline | 最高 |
 | Alacritty | Halfblocks | 基本 |
 | その他 | 自動検出 | 可変 |
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -14,7 +14,7 @@
 - 複数選択によるバッチ操作
 - **プレビューパネル**（以下に対応）:
   - テキストファイル（拡張子による構文ハイライト）
-  - 画像（半ブロック描画）
+  - 画像（Kitty/iTerm2/Sixelプロトコル、自動検出対応）
   - ディレクトリ（ファイル数、サイズ統計）
   - バイナリファイル（Hexダンプ表示）
 - 内部クリップボードによるコピー/カット/ペースト
@@ -40,6 +40,26 @@ Gitリポジトリ内では、ファイルの状態に応じて色分け表示�
 
 ステータスバーに現在のブランチ名が表示されます。
 
+## 画像プレビュー
+
+FileViewはターミナルを自動検出し、最適な画像プロトコルを選択します：
+
+| ターミナル | プロトコル | 品質 |
+|-----------|----------|------|
+| Kitty | Kitty Graphics | 最高 |
+| Ghostty | Kitty Graphics | 最高 |
+| Konsole | Kitty Graphics | 最高 |
+| iTerm2 | iTerm2 Inline | 最高 |
+| WezTerm | iTerm2 Inline | 最高 |
+| Warp | iTerm2 Inline | 最高 |
+| Foot | Sixel | 良好 |
+| Windows Terminal | Sixel | 良好 |
+| VS Code | Halfblocks | 基本 |
+| Alacritty | Halfblocks | 基本 |
+| その他 | 自動検出 | 可変 |
+
+`FILEVIEW_IMAGE_PROTOCOL` 環境変数でオーバーライド可能です（下記参照）。
+
 ## インストール
 
 ### crates.io から（推奨）
@@ -48,12 +68,31 @@ Gitリポジトリ内では、ファイルの状態に応じて色分け表示�
 cargo install fileview
 ```
 
+### Chafaサポート付き（オプション）
+
+ネイティブ画像プロトコル非対応のターミナルで高品質な画像プレビューを利用する場合：
+
+```bash
+# 先にlibchafaをインストール
+# macOS:
+brew install chafa
+
+# Ubuntu/Debian:
+sudo apt install libchafa-dev
+
+# その後、chafa featureを有効にしてインストール
+cargo install fileview --features chafa
+```
+
 ### ソースから
 
 ```bash
 git clone https://github.com/Hiro-Chiba/fileview.git
 cd fileview
 cargo install --path .
+
+# Chafaサポート付き:
+cargo install --path . --features chafa
 ```
 
 ### 動作要件
@@ -177,6 +216,7 @@ fv --on-select "code {path}"
 | 変数 | 説明 |
 |------|------|
 | `FILEVIEW_ICONS=0` | デフォルトでアイコンを無効化 |
+| `FILEVIEW_IMAGE_PROTOCOL` | 画像プロトコルを指定: `auto`, `halfblocks`, `chafa`, `sixel`, `kitty`, `iterm2` |
 
 ### `--on-select` のプレースホルダー
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -239,8 +239,8 @@ Total Size:  1.2 MB
 | 13. E2E / Behavioral Tests | 4 | 3 |
 | 14. Side Preview Focus | 5 | 5 |
 | 15. Image Protocol Support | 5 | 4 |
-| 16. Enhanced Image Preview | 5 | 4 |
-| **Total** | **54** | **51** |
+| 16. Enhanced Image Preview | 5 | 5 |
+| **Total** | **54** | **52** |
 
 **注意:** Phase 15.8（ratatui-image統合）が完了するまでv0.8.0のリリースは行わない。
 自作の画像プロトコル実装は削除し、ratatui-imageに一本化する。
@@ -993,10 +993,10 @@ pub fn create_image_picker() -> Option<Picker> {
 ### 16.5 ドキュメント更新
 **優先度:** 低
 
-- [ ] README更新
+- [x] README更新
   - 対応ターミナル一覧の更新
   - Chafaインストール手順
-- [ ] PR: `docs: Update image preview documentation`
+- [x] PR: `docs: Update image preview documentation`
 
 ### プロトコル品質比較
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3,6 +3,7 @@
 pub mod icons;
 pub mod preview;
 pub mod status;
+pub mod terminal;
 pub mod tree;
 
 pub use icons::get_icon;
@@ -13,59 +14,104 @@ pub use preview::{
 };
 pub use ratatui_image::picker::Picker;
 pub use status::{render_input_popup, render_status_bar};
+pub use terminal::{RecommendedProtocol, TerminalBrand};
 pub use tree::{render_tree, visible_height};
 
 /// Create an image picker for protocol detection
 ///
 /// This should be called BEFORE entering alternate screen mode.
-/// Tries to query terminal capabilities first, falls back to halfblock rendering.
+///
+/// Detection priority:
+/// 1. `FILEVIEW_IMAGE_PROTOCOL` environment variable (explicit override)
+/// 2. Terminal brand detection → recommended protocol
+/// 3. Query terminal capabilities via escape sequences
+/// 4. Chafa → Halfblocks fallback (Chafa requires `chafa` feature)
 ///
 /// Set environment variable `FILEVIEW_IMAGE_PROTOCOL` to control behavior:
 /// - `auto` (default): Auto-detect terminal protocol
 /// - `halfblocks`: Force halfblock rendering (most compatible)
+/// - `chafa`: Force Chafa rendering (requires `chafa` feature and libchafa)
 /// - `sixel`, `kitty`, `iterm2`: Force specific protocol
 pub fn create_image_picker() -> Option<Picker> {
     use ratatui_image::picker::ProtocolType;
 
-    // Check for environment variable override
+    // 1. Check for environment variable override (highest priority)
     if let Ok(protocol) = std::env::var("FILEVIEW_IMAGE_PROTOCOL") {
         match protocol.to_lowercase().as_str() {
             "halfblocks" | "half" => return Some(Picker::halfblocks()),
+            "chafa" => {
+                return try_chafa_picker().or_else(|| Some(Picker::halfblocks()));
+            }
             "sixel" => {
-                let mut picker = Picker::halfblocks();
-                picker.set_protocol_type(ProtocolType::Sixel);
-                return Some(picker);
+                return try_protocol(ProtocolType::Sixel);
             }
             "kitty" => {
-                let mut picker = Picker::halfblocks();
-                picker.set_protocol_type(ProtocolType::Kitty);
-                return Some(picker);
+                return try_protocol(ProtocolType::Kitty);
             }
             "iterm2" | "iterm" => {
-                let mut picker = Picker::halfblocks();
-                picker.set_protocol_type(ProtocolType::Iterm2);
-                return Some(picker);
+                return try_protocol(ProtocolType::Iterm2);
             }
             _ => {} // "auto" or unknown, continue with auto-detection
         }
     }
 
-    // VS Code terminal doesn't properly support advanced image protocols
-    // (ratatui-image detects it as iTerm2 compatible, but it doesn't work)
-    if is_vscode_terminal() {
-        return Some(Picker::halfblocks());
+    // 2. Terminal brand detection
+    let terminal = TerminalBrand::detect();
+    match terminal.recommended_protocol() {
+        RecommendedProtocol::Kitty => {
+            if let Some(picker) = try_protocol(ProtocolType::Kitty) {
+                return Some(picker);
+            }
+        }
+        RecommendedProtocol::Iterm2 => {
+            if let Some(picker) = try_protocol(ProtocolType::Iterm2) {
+                return Some(picker);
+            }
+        }
+        RecommendedProtocol::Sixel => {
+            if let Some(picker) = try_protocol(ProtocolType::Sixel) {
+                return Some(picker);
+            }
+        }
+        RecommendedProtocol::Chafa => {
+            // Terminals like VSCode/Alacritty prefer Chafa
+            if let Some(picker) = try_chafa_picker() {
+                return Some(picker);
+            }
+            // Fallback to halfblocks if Chafa not available
+            return Some(Picker::halfblocks());
+        }
+        RecommendedProtocol::Query => {
+            // Unknown terminal or tmux - try query first
+        }
     }
 
-    // Try to query terminal for image protocol support (Sixel/Kitty/iTerm2)
-    Picker::from_query_stdio().ok().or_else(|| {
-        // Fallback: use halfblock rendering
-        Some(Picker::halfblocks())
-    })
+    // 3. Query terminal capabilities (for unknown terminals or if brand-specific failed)
+    if let Ok(picker) = Picker::from_query_stdio() {
+        return Some(picker);
+    }
+
+    // 4. Fallback chain: Chafa → Halfblocks
+    try_chafa_picker().or_else(|| Some(Picker::halfblocks()))
 }
 
-/// Check if running in VS Code integrated terminal
-fn is_vscode_terminal() -> bool {
-    std::env::var("TERM_PROGRAM")
-        .map(|v| v.to_lowercase().contains("vscode"))
-        .unwrap_or(false)
+/// Try to create a picker with a specific protocol type
+fn try_protocol(protocol_type: ratatui_image::picker::ProtocolType) -> Option<Picker> {
+    let mut picker = Picker::halfblocks();
+    picker.set_protocol_type(protocol_type);
+    Some(picker)
+}
+
+/// Try to create a Chafa picker
+///
+/// Returns None if Chafa feature is not enabled or libchafa is not available
+#[cfg(feature = "chafa")]
+fn try_chafa_picker() -> Option<Picker> {
+    Picker::from_chafa().ok()
+}
+
+/// Fallback when Chafa feature is not enabled
+#[cfg(not(feature = "chafa"))]
+fn try_chafa_picker() -> Option<Picker> {
+    None
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -43,13 +43,13 @@ pub fn create_image_picker() -> Option<Picker> {
                 return try_chafa_picker().or_else(|| Some(Picker::halfblocks()));
             }
             "sixel" => {
-                return try_protocol(ProtocolType::Sixel);
+                return Some(picker_with_protocol(ProtocolType::Sixel));
             }
             "kitty" => {
-                return try_protocol(ProtocolType::Kitty);
+                return Some(picker_with_protocol(ProtocolType::Kitty));
             }
             "iterm2" | "iterm" => {
-                return try_protocol(ProtocolType::Iterm2);
+                return Some(picker_with_protocol(ProtocolType::Iterm2));
             }
             _ => {} // "auto" or unknown, continue with auto-detection
         }
@@ -59,19 +59,13 @@ pub fn create_image_picker() -> Option<Picker> {
     let terminal = TerminalBrand::detect();
     match terminal.recommended_protocol() {
         RecommendedProtocol::Kitty => {
-            if let Some(picker) = try_protocol(ProtocolType::Kitty) {
-                return Some(picker);
-            }
+            return Some(picker_with_protocol(ProtocolType::Kitty));
         }
         RecommendedProtocol::Iterm2 => {
-            if let Some(picker) = try_protocol(ProtocolType::Iterm2) {
-                return Some(picker);
-            }
+            return Some(picker_with_protocol(ProtocolType::Iterm2));
         }
         RecommendedProtocol::Sixel => {
-            if let Some(picker) = try_protocol(ProtocolType::Sixel) {
-                return Some(picker);
-            }
+            return Some(picker_with_protocol(ProtocolType::Sixel));
         }
         RecommendedProtocol::Chafa => {
             // Terminals like VSCode/Alacritty prefer Chafa
@@ -95,11 +89,11 @@ pub fn create_image_picker() -> Option<Picker> {
     try_chafa_picker().or_else(|| Some(Picker::halfblocks()))
 }
 
-/// Try to create a picker with a specific protocol type
-fn try_protocol(protocol_type: ratatui_image::picker::ProtocolType) -> Option<Picker> {
+/// Create a picker with a specific protocol type
+fn picker_with_protocol(protocol_type: ratatui_image::picker::ProtocolType) -> Picker {
     let mut picker = Picker::halfblocks();
     picker.set_protocol_type(protocol_type);
-    Some(picker)
+    picker
 }
 
 /// Try to create a Chafa picker

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -150,9 +150,8 @@ impl TerminalBrand {
             Self::Foot => RecommendedProtocol::Sixel,
             Self::WindowsTerminal => RecommendedProtocol::Sixel,
 
-            // VS Code supports iTerm2 inline images protocol
-            Self::VSCode => RecommendedProtocol::Iterm2,
-            // Alacritty has no native image protocol support
+            // VS Code/Alacritty: no reliable native protocol, use Chafa/Halfblocks
+            Self::VSCode => RecommendedProtocol::Chafa,
             Self::Alacritty => RecommendedProtocol::Chafa,
 
             // Query terminal or fallback
@@ -613,10 +612,10 @@ mod tests {
         }
 
         #[test]
-        fn vscode_recommends_iterm2() {
+        fn vscode_recommends_chafa() {
             assert_eq!(
                 TerminalBrand::VSCode.recommended_protocol(),
-                RecommendedProtocol::Iterm2
+                RecommendedProtocol::Chafa
             );
         }
 
@@ -838,7 +837,7 @@ mod tests {
             let protocol = brand.recommended_protocol();
 
             assert_eq!(brand, TerminalBrand::VSCode);
-            assert_eq!(protocol, RecommendedProtocol::Iterm2);
+            assert_eq!(protocol, RecommendedProtocol::Chafa);
         }
 
         #[test]

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -150,8 +150,9 @@ impl TerminalBrand {
             Self::Foot => RecommendedProtocol::Sixel,
             Self::WindowsTerminal => RecommendedProtocol::Sixel,
 
-            // Chafa preferred (no native protocol support)
-            Self::VSCode => RecommendedProtocol::Chafa,
+            // VS Code supports iTerm2 inline images protocol
+            Self::VSCode => RecommendedProtocol::Iterm2,
+            // Alacritty has no native image protocol support
             Self::Alacritty => RecommendedProtocol::Chafa,
 
             // Query terminal or fallback
@@ -612,10 +613,10 @@ mod tests {
         }
 
         #[test]
-        fn vscode_recommends_chafa() {
+        fn vscode_recommends_iterm2() {
             assert_eq!(
                 TerminalBrand::VSCode.recommended_protocol(),
-                RecommendedProtocol::Chafa
+                RecommendedProtocol::Iterm2
             );
         }
 
@@ -837,7 +838,7 @@ mod tests {
             let protocol = brand.recommended_protocol();
 
             assert_eq!(brand, TerminalBrand::VSCode);
-            assert_eq!(protocol, RecommendedProtocol::Chafa);
+            assert_eq!(protocol, RecommendedProtocol::Iterm2);
         }
 
         #[test]

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -1,0 +1,804 @@
+//! Terminal detection module - Detects terminal brands and recommends image protocols
+//!
+//! This module provides terminal brand detection based on environment variables,
+//! and maps each terminal to its recommended image protocol.
+
+/// Terminal brands that can be detected via environment variables
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalBrand {
+    /// Kitty terminal (KITTY_WINDOW_ID)
+    Kitty,
+    /// Ghostty terminal (GHOSTTY_RESOURCES_DIR)
+    Ghostty,
+    /// WezTerm (WEZTERM_EXECUTABLE)
+    WezTerm,
+    /// iTerm2 (TERM_PROGRAM=iTerm.app)
+    ITerm2,
+    /// KDE Konsole (TERMINAL=konsole)
+    Konsole,
+    /// Foot terminal (TERM=foot*)
+    Foot,
+    /// VS Code integrated terminal (TERM_PROGRAM=vscode)
+    VSCode,
+    /// Warp terminal (TERM_PROGRAM=WarpTerminal)
+    Warp,
+    /// Alacritty (TERM_PROGRAM=Alacritty)
+    Alacritty,
+    /// Windows Terminal (WT_SESSION)
+    WindowsTerminal,
+    /// Running inside tmux (TMUX)
+    Tmux,
+    /// Unknown terminal
+    Unknown,
+}
+
+/// Recommended image protocol for a terminal
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecommendedProtocol {
+    /// Kitty Graphics Protocol - highest quality, supported by Kitty, Ghostty, Konsole
+    Kitty,
+    /// iTerm2 Inline Images Protocol - supported by iTerm2, WezTerm, Warp
+    Iterm2,
+    /// Sixel graphics - supported by Foot, Windows Terminal, mlterm
+    Sixel,
+    /// Chafa preferred - for terminals without native protocol support (VSCode, Alacritty)
+    Chafa,
+    /// Query terminal capabilities - for unknown terminals or tmux
+    Query,
+}
+
+impl TerminalBrand {
+    /// Detect the terminal brand from environment variables
+    ///
+    /// Detection priority:
+    /// 1. Terminal-specific environment variables (most reliable)
+    /// 2. TERM_PROGRAM environment variable
+    /// 3. TERMINAL environment variable
+    /// 4. TERM environment variable
+    pub fn detect() -> Self {
+        Self::detect_from_env(&EnvReader::Real)
+    }
+
+    /// Internal detection with injectable environment reader (for testing)
+    fn detect_from_env(env: &dyn EnvReaderTrait) -> Self {
+        // 1. Terminal-specific environment variables (most reliable)
+
+        // Kitty sets KITTY_WINDOW_ID
+        if env.var("KITTY_WINDOW_ID").is_ok() {
+            return Self::Kitty;
+        }
+
+        // Ghostty sets GHOSTTY_RESOURCES_DIR
+        if env.var("GHOSTTY_RESOURCES_DIR").is_ok() {
+            return Self::Ghostty;
+        }
+
+        // WezTerm sets WEZTERM_EXECUTABLE
+        if env.var("WEZTERM_EXECUTABLE").is_ok() {
+            return Self::WezTerm;
+        }
+
+        // Windows Terminal sets WT_SESSION
+        if env.var("WT_SESSION").is_ok() {
+            return Self::WindowsTerminal;
+        }
+
+        // Tmux sets TMUX
+        if env.var("TMUX").is_ok() {
+            return Self::Tmux;
+        }
+
+        // 2. TERM_PROGRAM based detection
+        if let Ok(term_program) = env.var("TERM_PROGRAM") {
+            let term_lower = term_program.to_lowercase();
+
+            // iTerm2 sets TERM_PROGRAM=iTerm.app
+            if term_lower.contains("iterm") {
+                return Self::ITerm2;
+            }
+
+            // Warp sets TERM_PROGRAM=WarpTerminal
+            if term_lower.contains("warp") {
+                return Self::Warp;
+            }
+
+            // VS Code sets TERM_PROGRAM=vscode
+            if term_lower.contains("vscode") {
+                return Self::VSCode;
+            }
+
+            // Alacritty sets TERM_PROGRAM=Alacritty
+            if term_lower.contains("alacritty") {
+                return Self::Alacritty;
+            }
+        }
+
+        // 3. TERMINAL environment variable (used by some Linux distros)
+        if let Ok(terminal) = env.var("TERMINAL") {
+            if terminal.to_lowercase().contains("konsole") {
+                return Self::Konsole;
+            }
+        }
+
+        // 4. TERM environment variable (least specific)
+        if let Ok(term) = env.var("TERM") {
+            let term_lower = term.to_lowercase();
+
+            // Foot sets TERM=foot or TERM=foot-extra
+            if term_lower.starts_with("foot") {
+                return Self::Foot;
+            }
+        }
+
+        Self::Unknown
+    }
+
+    /// Get the recommended protocol for this terminal
+    pub fn recommended_protocol(&self) -> RecommendedProtocol {
+        match self {
+            // Kitty protocol terminals (True color, highest quality)
+            Self::Kitty => RecommendedProtocol::Kitty,
+            Self::Ghostty => RecommendedProtocol::Kitty,
+            Self::Konsole => RecommendedProtocol::Kitty,
+
+            // iTerm2 protocol terminals (True color, high quality)
+            Self::ITerm2 => RecommendedProtocol::Iterm2,
+            Self::WezTerm => RecommendedProtocol::Iterm2,
+            Self::Warp => RecommendedProtocol::Iterm2,
+
+            // Sixel protocol terminals (256 colors, good quality)
+            Self::Foot => RecommendedProtocol::Sixel,
+            Self::WindowsTerminal => RecommendedProtocol::Sixel,
+
+            // Chafa preferred (no native protocol support)
+            Self::VSCode => RecommendedProtocol::Chafa,
+            Self::Alacritty => RecommendedProtocol::Chafa,
+
+            // Query terminal or fallback
+            Self::Tmux => RecommendedProtocol::Query,
+            Self::Unknown => RecommendedProtocol::Query,
+        }
+    }
+
+    /// Get the terminal brand name as a string
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Kitty => "Kitty",
+            Self::Ghostty => "Ghostty",
+            Self::WezTerm => "WezTerm",
+            Self::ITerm2 => "iTerm2",
+            Self::Konsole => "Konsole",
+            Self::Foot => "Foot",
+            Self::VSCode => "VS Code",
+            Self::Warp => "Warp",
+            Self::Alacritty => "Alacritty",
+            Self::WindowsTerminal => "Windows Terminal",
+            Self::Tmux => "tmux",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+impl RecommendedProtocol {
+    /// Get the protocol name as a string
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Kitty => "Kitty Graphics Protocol",
+            Self::Iterm2 => "iTerm2 Inline Images",
+            Self::Sixel => "Sixel",
+            Self::Chafa => "Chafa",
+            Self::Query => "Query/Auto-detect",
+        }
+    }
+}
+
+// =============================================================================
+// Environment Reader Trait (for testability)
+// =============================================================================
+
+/// Trait for reading environment variables (allows mocking in tests)
+trait EnvReaderTrait {
+    fn var(&self, key: &str) -> Result<String, std::env::VarError>;
+}
+
+/// Real environment reader
+enum EnvReader {
+    Real,
+}
+
+impl EnvReaderTrait for EnvReader {
+    fn var(&self, key: &str) -> Result<String, std::env::VarError> {
+        std::env::var(key)
+    }
+}
+
+/// Mock environment reader for testing
+#[cfg(test)]
+struct MockEnvReader {
+    vars: std::collections::HashMap<String, String>,
+}
+
+#[cfg(test)]
+impl MockEnvReader {
+    fn new() -> Self {
+        Self {
+            vars: std::collections::HashMap::new(),
+        }
+    }
+
+    fn set(&mut self, key: &str, value: &str) -> &mut Self {
+        self.vars.insert(key.to_string(), value.to_string());
+        self
+    }
+}
+
+#[cfg(test)]
+impl EnvReaderTrait for MockEnvReader {
+    fn var(&self, key: &str) -> Result<String, std::env::VarError> {
+        self.vars
+            .get(key)
+            .cloned()
+            .ok_or(std::env::VarError::NotPresent)
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // TerminalBrand Detection Tests
+    // =========================================================================
+
+    mod detection {
+        use super::*;
+
+        #[test]
+        fn detects_kitty_from_kitty_window_id() {
+            let mut env = MockEnvReader::new();
+            env.set("KITTY_WINDOW_ID", "1");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Kitty);
+        }
+
+        #[test]
+        fn detects_ghostty_from_ghostty_resources_dir() {
+            let mut env = MockEnvReader::new();
+            env.set("GHOSTTY_RESOURCES_DIR", "/usr/share/ghostty");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Ghostty);
+        }
+
+        #[test]
+        fn detects_wezterm_from_wezterm_executable() {
+            let mut env = MockEnvReader::new();
+            env.set("WEZTERM_EXECUTABLE", "/usr/bin/wezterm");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::WezTerm);
+        }
+
+        #[test]
+        fn detects_windows_terminal_from_wt_session() {
+            let mut env = MockEnvReader::new();
+            env.set("WT_SESSION", "some-guid");
+
+            assert_eq!(
+                TerminalBrand::detect_from_env(&env),
+                TerminalBrand::WindowsTerminal
+            );
+        }
+
+        #[test]
+        fn detects_tmux_from_tmux_env() {
+            let mut env = MockEnvReader::new();
+            env.set("TMUX", "/tmp/tmux-1000/default,12345,0");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Tmux);
+        }
+
+        #[test]
+        fn detects_iterm2_from_term_program() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM_PROGRAM", "iTerm.app");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::ITerm2);
+        }
+
+        #[test]
+        fn detects_iterm2_case_insensitive() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM_PROGRAM", "ITERM.APP");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::ITerm2);
+        }
+
+        #[test]
+        fn detects_warp_from_term_program() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM_PROGRAM", "WarpTerminal");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Warp);
+        }
+
+        #[test]
+        fn detects_vscode_from_term_program() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM_PROGRAM", "vscode");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::VSCode);
+        }
+
+        #[test]
+        fn detects_alacritty_from_term_program() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM_PROGRAM", "Alacritty");
+
+            assert_eq!(
+                TerminalBrand::detect_from_env(&env),
+                TerminalBrand::Alacritty
+            );
+        }
+
+        #[test]
+        fn detects_konsole_from_terminal_env() {
+            let mut env = MockEnvReader::new();
+            env.set("TERMINAL", "konsole");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Konsole);
+        }
+
+        #[test]
+        fn detects_foot_from_term_env() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM", "foot");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Foot);
+        }
+
+        #[test]
+        fn detects_foot_extra_from_term_env() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM", "foot-extra");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Foot);
+        }
+
+        #[test]
+        fn returns_unknown_for_empty_env() {
+            let env = MockEnvReader::new();
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Unknown);
+        }
+
+        #[test]
+        fn returns_unknown_for_unrecognized_term_program() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM_PROGRAM", "SomeUnknownTerminal");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Unknown);
+        }
+
+        #[test]
+        fn returns_unknown_for_generic_term() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM", "xterm-256color");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Unknown);
+        }
+    }
+
+    // =========================================================================
+    // Detection Priority Tests
+    // =========================================================================
+
+    mod priority {
+        use super::*;
+
+        #[test]
+        fn kitty_takes_priority_over_term_program() {
+            let mut env = MockEnvReader::new();
+            env.set("KITTY_WINDOW_ID", "1");
+            env.set("TERM_PROGRAM", "vscode"); // Should be ignored
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Kitty);
+        }
+
+        #[test]
+        fn ghostty_takes_priority_over_term_program() {
+            let mut env = MockEnvReader::new();
+            env.set("GHOSTTY_RESOURCES_DIR", "/path");
+            env.set("TERM_PROGRAM", "Alacritty"); // Should be ignored
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Ghostty);
+        }
+
+        #[test]
+        fn wezterm_takes_priority_over_term_program() {
+            let mut env = MockEnvReader::new();
+            env.set("WEZTERM_EXECUTABLE", "/path");
+            env.set("TERM_PROGRAM", "iTerm.app"); // Should be ignored
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::WezTerm);
+        }
+
+        #[test]
+        fn windows_terminal_takes_priority_over_term() {
+            let mut env = MockEnvReader::new();
+            env.set("WT_SESSION", "guid");
+            env.set("TERM", "foot"); // Should be ignored
+
+            assert_eq!(
+                TerminalBrand::detect_from_env(&env),
+                TerminalBrand::WindowsTerminal
+            );
+        }
+
+        #[test]
+        fn tmux_takes_priority_over_term_program() {
+            let mut env = MockEnvReader::new();
+            env.set("TMUX", "/tmp/tmux");
+            env.set("TERM_PROGRAM", "iTerm.app"); // Should be ignored
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Tmux);
+        }
+
+        #[test]
+        fn term_program_takes_priority_over_terminal() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM_PROGRAM", "vscode");
+            env.set("TERMINAL", "konsole"); // Should be ignored
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::VSCode);
+        }
+
+        #[test]
+        fn terminal_takes_priority_over_term() {
+            let mut env = MockEnvReader::new();
+            env.set("TERMINAL", "konsole");
+            env.set("TERM", "foot"); // Should be ignored
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Konsole);
+        }
+
+        #[test]
+        fn kitty_inside_tmux_detects_kitty() {
+            // When running tmux inside Kitty, both vars are set
+            // Kitty-specific var should take priority
+            let mut env = MockEnvReader::new();
+            env.set("KITTY_WINDOW_ID", "1");
+            env.set("TMUX", "/tmp/tmux");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Kitty);
+        }
+    }
+
+    // =========================================================================
+    // Protocol Recommendation Tests
+    // =========================================================================
+
+    mod protocol {
+        use super::*;
+
+        #[test]
+        fn kitty_recommends_kitty_protocol() {
+            assert_eq!(
+                TerminalBrand::Kitty.recommended_protocol(),
+                RecommendedProtocol::Kitty
+            );
+        }
+
+        #[test]
+        fn ghostty_recommends_kitty_protocol() {
+            assert_eq!(
+                TerminalBrand::Ghostty.recommended_protocol(),
+                RecommendedProtocol::Kitty
+            );
+        }
+
+        #[test]
+        fn konsole_recommends_kitty_protocol() {
+            assert_eq!(
+                TerminalBrand::Konsole.recommended_protocol(),
+                RecommendedProtocol::Kitty
+            );
+        }
+
+        #[test]
+        fn iterm2_recommends_iterm2_protocol() {
+            assert_eq!(
+                TerminalBrand::ITerm2.recommended_protocol(),
+                RecommendedProtocol::Iterm2
+            );
+        }
+
+        #[test]
+        fn wezterm_recommends_iterm2_protocol() {
+            assert_eq!(
+                TerminalBrand::WezTerm.recommended_protocol(),
+                RecommendedProtocol::Iterm2
+            );
+        }
+
+        #[test]
+        fn warp_recommends_iterm2_protocol() {
+            assert_eq!(
+                TerminalBrand::Warp.recommended_protocol(),
+                RecommendedProtocol::Iterm2
+            );
+        }
+
+        #[test]
+        fn foot_recommends_sixel_protocol() {
+            assert_eq!(
+                TerminalBrand::Foot.recommended_protocol(),
+                RecommendedProtocol::Sixel
+            );
+        }
+
+        #[test]
+        fn windows_terminal_recommends_sixel_protocol() {
+            assert_eq!(
+                TerminalBrand::WindowsTerminal.recommended_protocol(),
+                RecommendedProtocol::Sixel
+            );
+        }
+
+        #[test]
+        fn vscode_recommends_chafa() {
+            assert_eq!(
+                TerminalBrand::VSCode.recommended_protocol(),
+                RecommendedProtocol::Chafa
+            );
+        }
+
+        #[test]
+        fn alacritty_recommends_chafa() {
+            assert_eq!(
+                TerminalBrand::Alacritty.recommended_protocol(),
+                RecommendedProtocol::Chafa
+            );
+        }
+
+        #[test]
+        fn tmux_recommends_query() {
+            assert_eq!(
+                TerminalBrand::Tmux.recommended_protocol(),
+                RecommendedProtocol::Query
+            );
+        }
+
+        #[test]
+        fn unknown_recommends_query() {
+            assert_eq!(
+                TerminalBrand::Unknown.recommended_protocol(),
+                RecommendedProtocol::Query
+            );
+        }
+    }
+
+    // =========================================================================
+    // Name Tests
+    // =========================================================================
+
+    mod names {
+        use super::*;
+
+        #[test]
+        fn terminal_brand_names() {
+            assert_eq!(TerminalBrand::Kitty.name(), "Kitty");
+            assert_eq!(TerminalBrand::Ghostty.name(), "Ghostty");
+            assert_eq!(TerminalBrand::WezTerm.name(), "WezTerm");
+            assert_eq!(TerminalBrand::ITerm2.name(), "iTerm2");
+            assert_eq!(TerminalBrand::Konsole.name(), "Konsole");
+            assert_eq!(TerminalBrand::Foot.name(), "Foot");
+            assert_eq!(TerminalBrand::VSCode.name(), "VS Code");
+            assert_eq!(TerminalBrand::Warp.name(), "Warp");
+            assert_eq!(TerminalBrand::Alacritty.name(), "Alacritty");
+            assert_eq!(TerminalBrand::WindowsTerminal.name(), "Windows Terminal");
+            assert_eq!(TerminalBrand::Tmux.name(), "tmux");
+            assert_eq!(TerminalBrand::Unknown.name(), "Unknown");
+        }
+
+        #[test]
+        fn protocol_names() {
+            assert_eq!(RecommendedProtocol::Kitty.name(), "Kitty Graphics Protocol");
+            assert_eq!(RecommendedProtocol::Iterm2.name(), "iTerm2 Inline Images");
+            assert_eq!(RecommendedProtocol::Sixel.name(), "Sixel");
+            assert_eq!(RecommendedProtocol::Chafa.name(), "Chafa");
+            assert_eq!(RecommendedProtocol::Query.name(), "Query/Auto-detect");
+        }
+    }
+
+    // =========================================================================
+    // Edge Case Tests
+    // =========================================================================
+
+    mod edge_cases {
+        use super::*;
+
+        #[test]
+        fn empty_env_var_values_are_still_detected() {
+            let mut env = MockEnvReader::new();
+            env.set("KITTY_WINDOW_ID", ""); // Empty but present
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Kitty);
+        }
+
+        #[test]
+        fn whitespace_in_term_program_is_handled() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM_PROGRAM", "  iTerm.app  ");
+
+            // Contains "iterm" so should match
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::ITerm2);
+        }
+
+        #[test]
+        fn mixed_case_term_program_is_detected() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM_PROGRAM", "VSCODE");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::VSCode);
+        }
+
+        #[test]
+        fn partial_match_in_terminal_env() {
+            let mut env = MockEnvReader::new();
+            env.set("TERMINAL", "org.kde.konsole");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Konsole);
+        }
+
+        #[test]
+        fn foot_direct_term_match() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM", "foot-direct");
+
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Foot);
+        }
+
+        #[test]
+        fn xterm_does_not_match_foot() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM", "xterm-256color");
+
+            // xterm should not match foot
+            assert_eq!(TerminalBrand::detect_from_env(&env), TerminalBrand::Unknown);
+        }
+    }
+
+    // =========================================================================
+    // Integration-style Tests
+    // =========================================================================
+
+    mod integration {
+        use super::*;
+
+        #[test]
+        fn full_detection_to_protocol_flow_kitty() {
+            let mut env = MockEnvReader::new();
+            env.set("KITTY_WINDOW_ID", "1");
+            env.set("TERM", "xterm-kitty");
+
+            let brand = TerminalBrand::detect_from_env(&env);
+            let protocol = brand.recommended_protocol();
+
+            assert_eq!(brand, TerminalBrand::Kitty);
+            assert_eq!(protocol, RecommendedProtocol::Kitty);
+            assert_eq!(brand.name(), "Kitty");
+            assert_eq!(protocol.name(), "Kitty Graphics Protocol");
+        }
+
+        #[test]
+        fn full_detection_to_protocol_flow_vscode() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM_PROGRAM", "vscode");
+            env.set("TERM", "xterm-256color");
+
+            let brand = TerminalBrand::detect_from_env(&env);
+            let protocol = brand.recommended_protocol();
+
+            assert_eq!(brand, TerminalBrand::VSCode);
+            assert_eq!(protocol, RecommendedProtocol::Chafa);
+        }
+
+        #[test]
+        fn full_detection_to_protocol_flow_unknown() {
+            let mut env = MockEnvReader::new();
+            env.set("TERM", "linux");
+
+            let brand = TerminalBrand::detect_from_env(&env);
+            let protocol = brand.recommended_protocol();
+
+            assert_eq!(brand, TerminalBrand::Unknown);
+            assert_eq!(protocol, RecommendedProtocol::Query);
+        }
+    }
+
+    // =========================================================================
+    // Exhaustiveness Tests
+    // =========================================================================
+
+    mod exhaustiveness {
+        use super::*;
+
+        #[test]
+        fn all_terminal_brands_have_protocol() {
+            // Ensure every TerminalBrand variant has a defined protocol
+            let brands = [
+                TerminalBrand::Kitty,
+                TerminalBrand::Ghostty,
+                TerminalBrand::WezTerm,
+                TerminalBrand::ITerm2,
+                TerminalBrand::Konsole,
+                TerminalBrand::Foot,
+                TerminalBrand::VSCode,
+                TerminalBrand::Warp,
+                TerminalBrand::Alacritty,
+                TerminalBrand::WindowsTerminal,
+                TerminalBrand::Tmux,
+                TerminalBrand::Unknown,
+            ];
+
+            for brand in brands {
+                // This should not panic
+                let _ = brand.recommended_protocol();
+                let _ = brand.name();
+            }
+        }
+
+        #[test]
+        fn all_protocols_have_name() {
+            let protocols = [
+                RecommendedProtocol::Kitty,
+                RecommendedProtocol::Iterm2,
+                RecommendedProtocol::Sixel,
+                RecommendedProtocol::Chafa,
+                RecommendedProtocol::Query,
+            ];
+
+            for protocol in protocols {
+                assert!(!protocol.name().is_empty());
+            }
+        }
+
+        #[test]
+        fn terminal_brand_count() {
+            // Verify we have the expected number of terminal brands
+            // This helps catch if someone adds a new variant without tests
+            let brands = [
+                TerminalBrand::Kitty,
+                TerminalBrand::Ghostty,
+                TerminalBrand::WezTerm,
+                TerminalBrand::ITerm2,
+                TerminalBrand::Konsole,
+                TerminalBrand::Foot,
+                TerminalBrand::VSCode,
+                TerminalBrand::Warp,
+                TerminalBrand::Alacritty,
+                TerminalBrand::WindowsTerminal,
+                TerminalBrand::Tmux,
+                TerminalBrand::Unknown,
+            ];
+
+            assert_eq!(brands.len(), 12);
+        }
+
+        #[test]
+        fn protocol_count() {
+            let protocols = [
+                RecommendedProtocol::Kitty,
+                RecommendedProtocol::Iterm2,
+                RecommendedProtocol::Sixel,
+                RecommendedProtocol::Chafa,
+                RecommendedProtocol::Query,
+            ];
+
+            assert_eq!(protocols.len(), 5);
+        }
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3078,8 +3078,8 @@ mod terminal_detection_tests {
 
     #[test]
     fn test_chafa_preferred_terminals() {
-        // Terminals that should prefer Chafa
-        let chafa_terminals = [TerminalBrand::VSCode, TerminalBrand::Alacritty];
+        // Terminals that should prefer Chafa (no native image protocol support)
+        let chafa_terminals = [TerminalBrand::Alacritty];
 
         for terminal in chafa_terminals {
             assert_eq!(
@@ -3089,6 +3089,16 @@ mod terminal_detection_tests {
                 terminal
             );
         }
+    }
+
+    #[test]
+    fn test_vscode_supports_iterm2() {
+        // VS Code supports iTerm2 inline images protocol
+        assert_eq!(
+            TerminalBrand::VSCode.recommended_protocol(),
+            RecommendedProtocol::Iterm2,
+            "VS Code should recommend iTerm2 protocol"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3079,7 +3079,7 @@ mod terminal_detection_tests {
     #[test]
     fn test_chafa_preferred_terminals() {
         // Terminals that should prefer Chafa (no native image protocol support)
-        let chafa_terminals = [TerminalBrand::Alacritty];
+        let chafa_terminals = [TerminalBrand::VSCode, TerminalBrand::Alacritty];
 
         for terminal in chafa_terminals {
             assert_eq!(
@@ -3089,16 +3089,6 @@ mod terminal_detection_tests {
                 terminal
             );
         }
-    }
-
-    #[test]
-    fn test_vscode_supports_iterm2() {
-        // VS Code supports iTerm2 inline images protocol
-        assert_eq!(
-            TerminalBrand::VSCode.recommended_protocol(),
-            RecommendedProtocol::Iterm2,
-            "VS Code should recommend iTerm2 protocol"
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implement Phase 16.1-16.4 of Enhanced Image Preview (yazi-inspired):

- Add terminal brand detection module with 12 supported terminals
- Refactor `create_image_picker()` with detection priority system
- Add optional `chafa` Cargo feature for better fallback quality
- Comprehensive test coverage (86 new tests)

## Terminal Detection

Detects terminal brand from environment variables and recommends optimal image protocol:

| Terminal | Detection | Protocol |
|----------|-----------|----------|
| Kitty | `KITTY_WINDOW_ID` | Kitty Graphics |
| Ghostty | `GHOSTTY_RESOURCES_DIR` | Kitty Graphics |
| WezTerm | `WEZTERM_EXECUTABLE` | iTerm2 Inline |
| iTerm2 | `TERM_PROGRAM=iTerm` | iTerm2 Inline |
| Konsole | `TERMINAL=konsole` | Kitty Graphics |
| Foot | `TERM=foot` | Sixel |
| Windows Terminal | `WT_SESSION` | Sixel |
| VSCode | `TERM_PROGRAM=vscode` | Chafa/Halfblocks |
| Alacritty | `TERM_PROGRAM=Alacritty` | Chafa/Halfblocks |
| Warp | `TERM_PROGRAM=Warp` | iTerm2 Inline |
| tmux | `TMUX` | Query |

## Protocol Detection Priority

1. `FILEVIEW_IMAGE_PROTOCOL` env var (explicit override)
2. Terminal brand detection → recommended protocol
3. `Picker::from_query_stdio()` (query terminal capabilities)
4. Chafa → Halfblocks fallback

## Chafa Feature

Optional Cargo feature for better fallback quality:
```bash
# Default (no libchafa required)
cargo install fileview

# With Chafa support (requires libchafa)
cargo install fileview --features chafa
```

## Test plan

- [x] All 179 unit tests pass
- [x] All 170 integration tests pass (145 existing + 25 new)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes