### PR TITLE
release: v1.2.0 - Real-time file watching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-01-30
+
+### Added
+- Real-time file watching: Automatically refreshes the tree and Git status when files change
+  - Uses `notify` crate with 500ms debouncing for efficient updates
+  - Eye icon () displayed in status bar when watching is active
+  - Disabled in stdin mode (file watching not applicable)
+
 ## [1.1.0] - 2026-01-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,12 +692,14 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "arboard",
  "crossterm",
  "image",
+ "notify",
+ "notify-debouncer-mini",
  "nucleo-matcher",
  "ratatui",
  "ratatui-image",
@@ -743,6 +745,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "funty"
@@ -903,6 +914,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1001,26 @@ dependencies = [
  "hashbrown",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1194,6 +1245,45 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a689eb4262184d9a1727f9087cd03883ea716682ab03ed24efec57d7716dccb8"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
+]
 
 [[package]]
 name = "nucleo-matcher"
@@ -2028,6 +2118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,6 +2553,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2725,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]
@@ -28,6 +28,8 @@ arboard = "3.4"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 ratatui-image = { version = "10.0.4", default-features = false, features = ["image-defaults", "crossterm"] }
 nucleo-matcher = "0.3"
+notify = "8.2"
+notify-debouncer-mini = "0.6"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -43,6 +43,8 @@ pub struct AppState {
     pub fuzzy_jump_target: Option<PathBuf>,
     /// Whether in stdin mode (file operations disabled)
     pub stdin_mode: bool,
+    /// Whether file watching is enabled
+    pub watch_enabled: bool,
 }
 
 impl AppState {
@@ -74,6 +76,7 @@ impl AppState {
             choosedir_path: None,
             fuzzy_jump_target: None,
             stdin_mode: false,
+            watch_enabled: false,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub mod handler;
 pub mod integrate;
 pub mod render;
 pub mod tree;
+pub mod watcher;

--- a/src/render/status.rs
+++ b/src/render/status.rs
@@ -17,16 +17,23 @@ pub fn render_status_bar(frame: &mut Frame, state: &AppState, total_entries: usi
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(area);
 
-    // Left: message or help hint, with git branch
+    // Left: message or help hint, with git branch and watch indicator
+    let watch_indicator = if state.watch_enabled {
+        "\u{f06e} " // Eye icon (nf-fa-eye) for file watching
+    } else {
+        ""
+    };
+
     let branch_info = state
         .git_status
         .as_ref()
         .and_then(|g| g.branch())
-        .map(|b| format!(" \u{e0a0} {} |", b)) // Git branch icon
+        .map(|b| format!("\u{e0a0} {} |", b)) // Git branch icon
         .unwrap_or_default();
 
     let message = state.message.as_deref().unwrap_or("? for help");
     let left_content = Line::from(vec![
+        Span::styled(watch_indicator, Style::default().fg(Color::Blue)),
         Span::styled(branch_info, Style::default().fg(Color::Green)),
         Span::raw(format!(" {}", message)),
     ]);

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -1,0 +1,48 @@
+//! File system watcher for real-time updates
+
+use notify_debouncer_mini::{new_debouncer, DebouncedEvent, Debouncer};
+use std::path::Path;
+use std::sync::mpsc::{channel, Receiver};
+use std::time::Duration;
+
+/// File watcher with debouncing for real-time file system monitoring
+pub struct FileWatcher {
+    _debouncer: Debouncer<notify::RecommendedWatcher>,
+    rx: Receiver<Result<Vec<DebouncedEvent>, notify::Error>>,
+}
+
+impl FileWatcher {
+    /// Create a new file watcher for the given root directory
+    ///
+    /// # Arguments
+    /// * `root` - Root directory to watch recursively
+    ///
+    /// # Returns
+    /// A new FileWatcher instance or an error if watcher initialization fails
+    pub fn new(root: &Path) -> anyhow::Result<Self> {
+        let (tx, rx) = channel();
+
+        let mut debouncer = new_debouncer(Duration::from_millis(500), move |res| {
+            let _ = tx.send(res);
+        })?;
+
+        debouncer
+            .watcher()
+            .watch(root, notify::RecursiveMode::Recursive)?;
+
+        Ok(Self {
+            _debouncer: debouncer,
+            rx,
+        })
+    }
+
+    /// Check for pending file change events (non-blocking)
+    ///
+    /// Returns Some with events if changes were detected, None otherwise
+    pub fn poll(&self) -> Option<Vec<DebouncedEvent>> {
+        match self.rx.try_recv() {
+            Ok(Ok(events)) => Some(events),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Real-time file watching with automatic tree and Git status refresh
- Uses `notify` crate with 500ms debouncing for efficient event handling
- Eye icon () displayed in status bar when watching is active
- Disabled in stdin mode (file watching not applicable)

## Changes

| File | Description |
|------|-------------|
| `Cargo.toml` | Add notify, notify-debouncer-mini dependencies |
| `src/watcher/mod.rs` | **New** FileWatcher implementation |
| `src/lib.rs` | Add watcher module |
| `src/core/state.rs` | Add watch_enabled field |
| `src/main.rs` | Integrate watcher initialization and polling |
| `src/render/status.rs` | Display watch indicator icon |
| `CHANGELOG.md` | v1.2.0 entry |

## Test plan

- [ ] `cargo build --release`
- [ ] `cargo test`
- [ ] `cargo clippy -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] Manual: Run `fv .` and verify eye icon appears in status bar
- [ ] Manual: Touch/create/delete files in another terminal and verify auto-refresh
- [ ] Manual: Run `find . -name "*.rs" | fv --stdin` and verify no eye icon (watching disabled)