### PR TITLE
fix: v1.2.1 - File watcher performance fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-01-30
+
+### Fixed
+- Fixed severe performance issue with file watcher: drain all pending events before refresh to prevent repeated expensive reloads
+
 ## [1.2.0] - 2026-01-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -694,7 +694,7 @@ fn run_app(
 
         // Check file watcher events (auto-refresh on file changes)
         if let Some(ref watcher) = file_watcher {
-            if watcher.poll().is_some() {
+            if watcher.poll() {
                 navigator.reload()?;
                 state.refresh_git_status();
                 // Silent auto-refresh - no message displayed

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -38,11 +38,14 @@ impl FileWatcher {
 
     /// Check for pending file change events (non-blocking)
     ///
-    /// Returns Some with events if changes were detected, None otherwise
-    pub fn poll(&self) -> Option<Vec<DebouncedEvent>> {
-        match self.rx.try_recv() {
-            Ok(Ok(events)) => Some(events),
-            _ => None,
+    /// Drains all pending events from the channel and returns true if any were found.
+    /// This prevents event buildup that could cause repeated expensive reloads.
+    pub fn poll(&self) -> bool {
+        let mut has_events = false;
+        // Drain all pending events to avoid buildup
+        while let Ok(Ok(_)) = self.rx.try_recv() {
+            has_events = true;
         }
+        has_events
     }
 }


### PR DESCRIPTION
## Summary

- Fixed severe performance issue with file watcher

## Problem

The file watcher was processing one event per loop iteration. When multiple events accumulated in the channel (common during file operations), `reload()` and `refresh_git_status()` were called repeatedly, causing the UI to become extremely slow.

## Solution

Changed `poll()` to drain all pending events from the channel and return a boolean. This ensures only one reload per batch of changes, regardless of how many events occurred.

## Test plan

- [ ] `cargo build --release`
- [ ] `cargo test`
- [ ] Manual: Run `fv .` in a large directory
- [ ] Manual: Create/delete multiple files rapidly - UI should remain responsive