### PR TITLE
fix: v1.2.2 - Exclude large directories from watching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-01-30
+
+### Fixed
+- Exclude large directories from file watching: `.git`, `target`, `node_modules`, etc.
+- Significantly improves performance by avoiding monitoring of build artifacts and dependencies
+
 ## [1.2.1] - 2026-01-30
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -1,24 +1,38 @@
 //! File system watcher for real-time updates
 
-use notify_debouncer_mini::{new_debouncer, DebouncedEvent, Debouncer};
+use notify::Watcher;
+use notify_debouncer_mini::{new_debouncer, Debouncer};
+use std::fs;
 use std::path::Path;
 use std::sync::mpsc::{channel, Receiver};
 use std::time::Duration;
 
+/// Directories to exclude from watching (common large/generated directories)
+const EXCLUDED_DIRS: &[&str] = &[
+    ".git",
+    "target",
+    "node_modules",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".cache",
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+    "vendor",
+];
+
 /// File watcher with debouncing for real-time file system monitoring
 pub struct FileWatcher {
     _debouncer: Debouncer<notify::RecommendedWatcher>,
-    rx: Receiver<Result<Vec<DebouncedEvent>, notify::Error>>,
+    rx: Receiver<Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>>,
 }
 
 impl FileWatcher {
     /// Create a new file watcher for the given root directory
     ///
-    /// # Arguments
-    /// * `root` - Root directory to watch recursively
-    ///
-    /// # Returns
-    /// A new FileWatcher instance or an error if watcher initialization fails
+    /// Excludes common large directories like .git, target, node_modules, etc.
     pub fn new(root: &Path) -> anyhow::Result<Self> {
         let (tx, rx) = channel();
 
@@ -26,14 +40,39 @@ impl FileWatcher {
             let _ = tx.send(res);
         })?;
 
-        debouncer
-            .watcher()
-            .watch(root, notify::RecursiveMode::Recursive)?;
+        // Watch directories individually, excluding large/generated ones
+        Self::watch_directory_tree(debouncer.watcher(), root)?;
 
         Ok(Self {
             _debouncer: debouncer,
             rx,
         })
+    }
+
+    /// Recursively watch directories, excluding common large directories
+    fn watch_directory_tree(watcher: &mut dyn Watcher, dir: &Path) -> anyhow::Result<()> {
+        // Watch this directory (non-recursive)
+        watcher.watch(dir, notify::RecursiveMode::NonRecursive)?;
+
+        // Recursively process subdirectories
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    // Check if this directory should be excluded
+                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                        if EXCLUDED_DIRS.contains(&name) {
+                            continue; // Skip excluded directories
+                        }
+                    }
+                    // Recursively watch subdirectory
+                    // Ignore errors for individual subdirectories (permission issues, etc.)
+                    let _ = Self::watch_directory_tree(watcher, &path);
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Check for pending file change events (non-blocking)


### PR DESCRIPTION
## Summary

Exclude large directories from file system watching to fix severe performance issues.

## Problem

v1.2.0-1.2.1 monitored all directories recursively, including:
- `target/` (9.1GB in this project)
- `.git/`
- `node_modules/`

This caused excessive resource usage and slow UI.

## Solution

Manually walk the directory tree and skip excluded directories:
- `.git`, `target`, `node_modules`, `.venv`, `venv`
- `__pycache__`, `.cache`, `dist`, `build`
- `.next`, `.nuxt`, `vendor`

## Test plan

- [x] `cargo build --release`
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual: Run `fv .` in a project with large target/ directory - should be responsive