### PR TITLE
release: v1.3.0 - Smart file watching + Git polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-01-30
+
+### Changed
+- Smart file watching: Only watches expanded directories (much lighter)
+- Git status polling: Updates every 3 seconds (shows changes in collapsed folders)
+
+### Performance
+- Significantly reduced resource usage on large projects
+- Watching adapts dynamically to user's view
+
 ## [1.2.2] - 2026-01-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "finl_unicode"
@@ -885,7 +885,7 @@ dependencies = [
  "rgb",
  "tiff",
  "zune-core 0.5.1",
- "zune-jpeg 0.5.11",
+ "zune-jpeg 0.5.12",
 ]
 
 [[package]]
@@ -3007,18 +3007,18 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.34"
+version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
+checksum = "dafd85c832c1b68bbb4ec0c72c7f6f4fc5179627d2bc7c26b30e4c0cc11e76cc"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.34"
+version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
+checksum = "7cb7e4e8436d9db52fbd6625dbf2f45243ab84994a72882ec8227b99e72b439a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3057,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2959ca473aae96a14ecedf501d20b3608d2825ba280d5adb57d651721885b0c2"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
 dependencies = [
  "zune-core 0.5.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/tree/navigator.rs
+++ b/src/tree/navigator.rs
@@ -127,7 +127,7 @@ impl TreeNavigator {
 
     /// Reload tree from filesystem
     pub fn reload(&mut self) -> anyhow::Result<()> {
-        let expanded_paths = self.collect_expanded_paths();
+        let expanded_paths = self.expanded_paths();
         self.root.load_children(self.show_hidden)?;
         self.restore_expanded(&expanded_paths)?;
         Ok(())
@@ -185,8 +185,10 @@ impl TreeNavigator {
         None
     }
 
-    /// Collect paths of all expanded entries
-    fn collect_expanded_paths(&self) -> Vec<PathBuf> {
+    /// Get all currently expanded directory paths
+    ///
+    /// Used for syncing file watcher with expanded directories.
+    pub fn expanded_paths(&self) -> Vec<PathBuf> {
         let mut paths = Vec::new();
         self.collect_expanded_in(&self.root, &mut paths);
         paths


### PR DESCRIPTION
## Summary
- Smart file watching: Only watches expanded directories (much lighter on resources)
- Git status polling: Updates every 3 seconds (shows changes in collapsed folders too)
- Dynamic sync: Watches adapt to user's view (expand = watch, collapse = unwatch)

## Changes
| File | Change |
|------|--------|
| `src/watcher/mod.rs` | Dynamic watch API with `sync_with_expanded()` |
| `src/main.rs` | Expanded state sync + Git polling integration |
| `src/tree/navigator.rs` | Public `expanded_paths()` method |
| `Cargo.toml` | version = "1.3.0" |
| `CHANGELOG.md` | v1.3.0 entry |

## Test plan
- [x] `cargo build --release`
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual test: Expand directory → file changes detected immediately
- [ ] Manual test: Collapse directory → file changes in that dir not detected (but Git status still updates)
- [ ] Manual test: Large project performance is acceptable