### PR TITLE
release: v1.6.1 - Toggle behavior for mode keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-01-31
+
+### Improved
+- **Toggle behavior for mode keys**: Same key that opens a mode can now close it
+  - `m`: Press again to cancel bookmark set mode
+  - `'`: Press again to cancel bookmark jump mode
+  - `F`: Press again to cancel filter input mode
+  - `/`: Press again to cancel search mode
+  - More intuitive UX - no need to remember that Esc closes modes
+
 ## [1.6.0] - 2026-01-31
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]


### PR DESCRIPTION
## Summary

Add toggle behavior for mode-opening keys - the same key that opens a mode can now close it.

## Changes

| Mode | Key | Before | After |
|------|-----|--------|-------|
| Bookmark Set | `m` | Esc only | `m` or Esc |
| Bookmark Jump | `'` | Esc only | `'` or Esc |
| Filter | `F` | Esc only | `F` or Esc |
| Search | `/` | Esc only | `/` or Esc |

Note: Help (`?`), Fuzzy Finder (`Ctrl+P`), and Preview (`o`) already had this behavior.

## Why

More intuitive UX - users don't need to remember that Esc closes modes. The same key that opens something can close it.

## Test plan

- [x] All 286 tests pass
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes