### PR TITLE
release: v1.7.0 - Status bar shows file size and mtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-01-31
+
+### Changed
+- **Status bar redesign**: Show file info instead of position indicator
+  - Display file size (e.g., `1.2 KB`, `4.5 MB`) for focused file
+  - Display relative modification time (e.g., `2h ago`, `Yesterday`, `Jan 30`)
+  - Format: `1.2 KB · 2h ago | Selected: 3`
+  - Directories show `--` for size
+
+### Removed
+- Position indicator (`1/20`) - visual position in the list is sufficient
+
 ## [1.6.3] - 2026-01-31
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.6.3"
+version = "1.7.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -199,7 +199,6 @@ pub fn run_app(
         let render_context = RenderContext {
             state: &state,
             entries,
-            total_entries,
             focused_path: focused_path.as_ref(),
             preview: &mut preview,
             fuzzy_results: &fuzzy_results,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -19,7 +19,6 @@ use crate::tree::TreeEntry;
 pub struct RenderContext<'a> {
     pub state: &'a AppState,
     pub entries: Vec<&'a TreeEntry>,
-    pub total_entries: usize,
     pub focused_path: Option<&'a PathBuf>,
     pub preview: &'a mut PreviewState,
     pub fuzzy_results: &'a [FuzzyMatch],
@@ -100,7 +99,7 @@ fn render_normal_mode(frame: &mut Frame, ctx: &mut RenderContext, size: Rect, fo
     render_tree(frame, ctx.state, &ctx.entries, tree_chunks[0]);
 
     // Render status bar
-    render_status_bar(frame, ctx.state, ctx.total_entries, tree_chunks[1]);
+    render_status_bar(frame, ctx.state, ctx.focused_path, tree_chunks[1]);
 
     // Render preview if visible
     if ctx.state.preview_visible && main_chunks.len() > 1 {


### PR DESCRIPTION
## Summary
- Replace position indicator (`1/20`) with file information
- Show file size in human-readable format (`1.2 KB`, `4.5 MB`)
- Show relative modification time (`2h ago`, `Yesterday`, `Jan 30`)
- Format: `1.2 KB · 2h ago | Selected: 3`

Based on market research of popular file managers (Ranger, Yazi, nnn, lf), file size and modification time are the most useful information to display.

## Test plan
- [x] `cargo test` - 286 tests pass
- [x] `cargo clippy -- -D warnings` - no warnings
- [x] `cargo fmt --all -- --check` - formatted