### PR TITLE
release: v1.7.2 - Better performance/functionality balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-01-31
+
+### Fixed
+- **Revert git status flag**: Restore `-uall` to show all untracked files individually
+  - `-unormal` in v1.7.1 hid individual files inside untracked directories
+
+### Performance
+- **Event polling**: Adjusted to 60ms (balanced between 50ms responsiveness and CPU savings)
+- **Git polling**: Remains at 5 seconds (good balance)
+
 ## [1.7.1] - 2026-01-31
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -252,8 +252,8 @@ pub fn run_app(
             }
         }
 
-        // Handle events (100ms timeout balances responsiveness and CPU usage)
-        if event::poll(Duration::from_millis(100))? {
+        // Handle events (60ms timeout balances responsiveness and CPU usage)
+        if event::poll(Duration::from_millis(60))? {
             match event::read()? {
                 Event::Key(key) => {
                     // Handle input buffer updates first

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -152,10 +152,9 @@ fn load_git_status(
     let mut dir_statuses: HashMap<PathBuf, FileStatus> = HashMap::new();
 
     // Get status with porcelain format for machine parsing
-    // Use -unormal instead of -uall for better performance on large repos
-    // -unormal shows untracked directories, -uall recursively lists all files
+    // -uall shows all untracked files (required for per-file status display)
     let output = Command::new("git")
-        .args(["status", "--porcelain=v1", "-unormal", "--ignored"])
+        .args(["status", "--porcelain=v1", "-uall", "--ignored"])
         .current_dir(repo_root)
         .output();
 


### PR DESCRIPTION
## Summary
Fix the balance between performance and functionality from v1.7.1:

### Changes
| Setting | v1.7.1 | v1.7.2 | Reason |
|---------|--------|--------|--------|
| Git status | `-unormal` | `-uall` | Restore full file visibility |
| Event polling | 100ms | 60ms | Better responsiveness |
| Git polling | 5s | 5s | Keep (good balance) |

### Why This Fix?
v1.7.1's `-unormal` flag caused a functionality regression:
- Individual untracked files inside untracked directories were hidden
- Users couldn't see the git status of new files in new directories

## Test plan
- [x] `cargo test` - all tests pass
- [x] `cargo clippy -- -D warnings` - no warnings
- [x] Manual verification of git status display