### PR TITLE
release: v1.9.0 - Archive preview and benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-01-31
+
+### Added
+- **Archive preview**: Preview contents of zip archives
+  - Supported formats: `.zip`, `.jar`, `.apk`, `.ipa`, `.xpi`, `.epub`
+  - Shows file list with sizes and dates
+  - Directories sorted first, then files alphabetically
+- **Benchmark documentation**: Added `docs/BENCHMARKS.md`
+  - Startup time: ~2.1ms (measured with hyperfine)
+
+### Dependencies
+- Added `zip` crate (v2.4) for archive reading
+
 ## [1.8.1] - 2026-01-31
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +69,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arboard"
@@ -307,10 +321,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "castaway"
@@ -346,6 +385,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +455,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -523,6 +593,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +611,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -573,6 +660,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -583,6 +671,17 @@ checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.10.0",
  "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -730,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -744,6 +843,7 @@ dependencies = [
  "ratatui",
  "ratatui-image",
  "tempfile",
+ "zip",
 ]
 
 [[package]]
@@ -848,9 +948,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -896,6 +998,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "icy_sixel"
@@ -954,6 +1065,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1101,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1170,6 +1300,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1577,6 +1728,16 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2254,6 +2415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +2538,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3100,6 +3278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3123,6 +3310,96 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.8.1"
+version = "1.9.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]
@@ -30,6 +30,7 @@ ratatui-image = { version = "10.0.4", default-features = false, features = ["ima
 nucleo-matcher = "0.3"
 notify = "8.2"
 notify-debouncer-mini = "0.6"
+zip = "2.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fv
 |---------|-------------|
 | Tree navigation | Expand/collapse with vim keys |
 | Multi-select | Batch operations on files |
-| Preview panel | Text, images, hex dump |
+| Preview panel | Text, images, archives, hex dump |
 | File operations | Create, rename, delete, copy/paste |
 | Fuzzy finder | `Ctrl+P` for quick search |
 | Mouse support | Click, scroll, drag |

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,37 @@
+# Fileview Benchmarks
+
+Benchmark results for fileview v1.9.0 on macOS (Apple Silicon).
+
+## Startup Time
+
+Measured using [hyperfine](https://github.com/sharkdp/hyperfine) with 3 warmup runs.
+
+### fv --help
+
+```
+Benchmark: ./target/release/fv --help
+  Time (mean ± σ):       2.1 ms ±   0.1 ms
+  Range (min … max):     1.9 ms …   2.9 ms
+```
+
+## Binary Size
+
+Release build with LTO and strip enabled:
+
+```
+Optimization: size (opt-level = "z")
+LTO: true
+Strip: true
+```
+
+## Test Environment
+
+- OS: macOS (Darwin 24.6.0)
+- Architecture: ARM64 (Apple Silicon)
+- Date: 2026-01-31
+
+## Notes
+
+- Startup time is consistently under 3ms
+- Binary is optimized for size with full LTO
+- No runtime dependencies required

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -9,9 +9,9 @@ use crate::app::PreviewState;
 use crate::core::{AppState, FocusTarget, ViewMode};
 use crate::handler::action::get_filename_str;
 use crate::render::{
-    render_directory_info, render_fuzzy_finder, render_help_popup, render_hex_preview,
-    render_image_preview, render_input_popup, render_status_bar, render_text_preview, render_tree,
-    FontSize, FuzzyMatch, Picker,
+    render_archive_preview, render_directory_info, render_fuzzy_finder, render_help_popup,
+    render_hex_preview, render_image_preview, render_input_popup, render_status_bar,
+    render_text_preview, render_tree, FontSize, FuzzyMatch, Picker,
 };
 use crate::tree::TreeEntry;
 
@@ -68,6 +68,8 @@ fn render_fullscreen_preview(
         render_image_preview(frame, ip, size, &title, false, font_size);
     } else if let Some(ref hp) = ctx.preview.hex {
         render_hex_preview(frame, hp, size, &title, false);
+    } else if let Some(ref ap) = ctx.preview.archive {
+        render_archive_preview(frame, ap, size, &title, false);
     } else {
         let block = Block::default().borders(Borders::ALL).title(title);
         let para = Paragraph::new("No preview available").block(block);
@@ -142,6 +144,8 @@ fn render_side_preview(
         render_image_preview(frame, ip, area, &title, preview_focused, font_size);
     } else if let Some(ref hp) = ctx.preview.hex {
         render_hex_preview(frame, hp, area, &title, preview_focused);
+    } else if let Some(ref ap) = ctx.preview.archive {
+        render_archive_preview(frame, ap, area, &title, preview_focused);
     } else {
         let border_style = if preview_focused {
             Style::default().fg(Color::Cyan)

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -10,9 +10,10 @@ pub mod tree;
 pub use fuzzy::{collect_paths, fuzzy_match, render_fuzzy_finder, FuzzyMatch};
 pub use icons::get_icon;
 pub use preview::{
-    calculate_centered_image_area, is_binary_file, is_image_file, is_text_file,
-    render_directory_info, render_hex_preview, render_image_preview, render_text_preview,
-    DirectoryInfo, HexPreview, ImagePreview, TextPreview,
+    calculate_centered_image_area, is_archive_file, is_binary_file, is_image_file, is_text_file,
+    render_archive_preview, render_directory_info, render_hex_preview, render_image_preview,
+    render_text_preview, ArchiveEntry, ArchivePreview, DirectoryInfo, HexPreview, ImagePreview,
+    TextPreview,
 };
 pub use ratatui_image::picker::Picker;
 pub use ratatui_image::FontSize;

--- a/src/render/preview.rs
+++ b/src/render/preview.rs
@@ -448,14 +448,9 @@ impl ArchivePreview {
             let name = entry.name().to_string();
 
             // Format modified time if available
-            let modified = entry.last_modified().map(|dt| {
-                format!(
-                    "{:04}-{:02}-{:02}",
-                    dt.year(),
-                    dt.month(),
-                    dt.day()
-                )
-            });
+            let modified = entry
+                .last_modified()
+                .map(|dt| format!("{:04}-{:02}-{:02}", dt.year(), dt.month(), dt.day()));
 
             if !is_dir {
                 total_size += size;
@@ -505,16 +500,14 @@ pub fn render_archive_preview(
     let mut lines: Vec<Line> = Vec::new();
 
     // Header: archive info
-    lines.push(Line::from(vec![
-        Span::styled(
-            format!(
-                "  {} files, {}",
-                preview.file_count,
-                format_size(preview.total_size)
-            ),
-            Style::default().fg(Color::Cyan),
+    lines.push(Line::from(vec![Span::styled(
+        format!(
+            "  {} files, {}",
+            preview.file_count,
+            format_size(preview.total_size)
         ),
-    ]));
+        Style::default().fg(Color::Cyan),
+    )]));
 
     lines.push(Line::from(vec![Span::styled(
         format!("  {}", separator),
@@ -526,7 +519,12 @@ pub fn render_archive_preview(
     let content_start = preview.scroll.saturating_sub(header_lines);
 
     // Entry list
-    for entry in preview.entries.iter().skip(content_start).take(visible_height.saturating_sub(header_lines)) {
+    for entry in preview
+        .entries
+        .iter()
+        .skip(content_start)
+        .take(visible_height.saturating_sub(header_lines))
+    {
         let (icon, color) = if entry.is_dir {
             ("\u{f07b}", Color::Blue) // Folder icon
         } else {

--- a/src/render/preview.rs
+++ b/src/render/preview.rs
@@ -1,4 +1,4 @@
-//! Preview rendering (text, images, and directory info)
+//! Preview rendering (text, images, directory info, and archives)
 
 use std::path::Path;
 
@@ -20,6 +20,9 @@ const HEX_PREVIEW_MAX_BYTES: usize = 4096;
 
 /// Number of bytes per line in hex preview
 const HEX_BYTES_PER_LINE: usize = 16;
+
+/// Maximum entries to display in archive preview
+const ARCHIVE_MAX_ENTRIES: usize = 500;
 
 /// Text preview content
 pub struct TextPreview {
@@ -403,6 +406,179 @@ impl HexPreview {
     }
 }
 
+/// Archive entry information
+#[derive(Debug, Clone)]
+pub struct ArchiveEntry {
+    /// File/directory name (full path within archive)
+    pub name: String,
+    /// Size in bytes (0 for directories)
+    pub size: u64,
+    /// Whether this is a directory
+    pub is_dir: bool,
+    /// Last modified time (optional)
+    pub modified: Option<String>,
+}
+
+/// Archive preview content
+pub struct ArchivePreview {
+    /// Archive entries
+    pub entries: Vec<ArchiveEntry>,
+    /// Total uncompressed size
+    pub total_size: u64,
+    /// Number of files (not directories)
+    pub file_count: usize,
+    /// Scroll position
+    pub scroll: usize,
+}
+
+impl ArchivePreview {
+    /// Load archive preview from zip file
+    pub fn load_zip(path: &Path) -> anyhow::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let mut archive = zip::ZipArchive::new(file)?;
+
+        let mut entries = Vec::new();
+        let mut total_size = 0u64;
+        let mut file_count = 0usize;
+
+        for i in 0..archive.len().min(ARCHIVE_MAX_ENTRIES) {
+            let entry = archive.by_index(i)?;
+            let is_dir = entry.is_dir();
+            let size = entry.size();
+            let name = entry.name().to_string();
+
+            // Format modified time if available
+            let modified = entry.last_modified().map(|dt| {
+                format!(
+                    "{:04}-{:02}-{:02}",
+                    dt.year(),
+                    dt.month(),
+                    dt.day()
+                )
+            });
+
+            if !is_dir {
+                total_size += size;
+                file_count += 1;
+            }
+
+            entries.push(ArchiveEntry {
+                name,
+                size,
+                is_dir,
+                modified,
+            });
+        }
+
+        // Sort entries: directories first, then files, both alphabetically
+        entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.name.cmp(&b.name),
+        });
+
+        Ok(Self {
+            entries,
+            total_size,
+            file_count,
+            scroll: 0,
+        })
+    }
+
+    /// Get visible line count
+    pub fn line_count(&self) -> usize {
+        self.entries.len() + 2 // +2 for header lines
+    }
+}
+
+/// Render archive preview
+pub fn render_archive_preview(
+    frame: &mut Frame,
+    preview: &ArchivePreview,
+    area: Rect,
+    title: &str,
+    focused: bool,
+) {
+    let visible_height = area.height.saturating_sub(2) as usize;
+    let separator = "─".repeat(area.width.saturating_sub(4) as usize);
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Header: archive info
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!(
+                "  {} files, {}",
+                preview.file_count,
+                format_size(preview.total_size)
+            ),
+            Style::default().fg(Color::Cyan),
+        ),
+    ]));
+
+    lines.push(Line::from(vec![Span::styled(
+        format!("  {}", separator),
+        Style::default().fg(Color::DarkGray),
+    )]));
+
+    // Skip header lines in scroll calculation
+    let header_lines = 2;
+    let content_start = preview.scroll.saturating_sub(header_lines);
+
+    // Entry list
+    for entry in preview.entries.iter().skip(content_start).take(visible_height.saturating_sub(header_lines)) {
+        let (icon, color) = if entry.is_dir {
+            ("\u{f07b}", Color::Blue) // Folder icon
+        } else {
+            ("\u{f016}", Color::White) // File icon
+        };
+
+        let size_str = if entry.is_dir {
+            String::new()
+        } else {
+            format_size(entry.size)
+        };
+
+        let date_str = entry.modified.as_deref().unwrap_or("");
+
+        // Calculate name display width
+        let max_name_width = area.width.saturating_sub(24) as usize;
+        let display_name = if entry.name.len() > max_name_width {
+            format!("{}...", &entry.name[..max_name_width.saturating_sub(3)])
+        } else {
+            entry.name.clone()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {} ", icon), Style::default().fg(color)),
+            Span::styled(
+                format!("{:<width$}", display_name, width = max_name_width),
+                Style::default().fg(color),
+            ),
+            Span::styled(
+                format!("{:>8}  ", size_str),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled(date_str.to_string(), Style::default().fg(Color::DarkGray)),
+        ]));
+    }
+
+    let border_style = if focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default()
+    };
+
+    let widget = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" {} ", title))
+            .border_style(border_style),
+    );
+
+    frame.render_widget(widget, area);
+}
+
 /// Render hex preview (xxd-style)
 pub fn render_hex_preview(
     frame: &mut Frame,
@@ -505,10 +681,10 @@ fn render_hex_line(offset: usize, bytes: &[u8]) -> Line<'static> {
     Line::from(spans)
 }
 
-/// Check if a file is likely a binary file (not text, not image)
+/// Check if a file is likely a binary file (not text, not image, not archive)
 pub fn is_binary_file(path: &Path) -> bool {
-    // If it's a known text or image file, it's not binary
-    if is_text_file(path) || is_image_file(path) {
+    // If it's a known text, image, or archive file, it's not binary
+    if is_text_file(path) || is_image_file(path) || is_archive_file(path) {
         return false;
     }
 
@@ -635,6 +811,19 @@ pub fn is_image_file(path: &std::path::Path) -> bool {
     matches!(
         ext.as_deref(),
         Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "ico")
+    )
+}
+
+/// Check if a file is a zip archive
+pub fn is_archive_file(path: &std::path::Path) -> bool {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase());
+
+    matches!(
+        ext.as_deref(),
+        Some("zip" | "jar" | "apk" | "ipa" | "xpi" | "epub")
     )
 }
 


### PR DESCRIPTION
## Summary
- **Archive preview**: Preview contents of zip archives (.zip, .jar, .apk, .ipa, .xpi, .epub)
- **Benchmark documentation**: Added `docs/BENCHMARKS.md` with startup time measurements (~2.1ms)

## Changes
- Added `zip` crate (v2.4) for archive reading
- New `ArchivePreview`, `ArchiveEntry` structs
- New `render_archive_preview()`, `is_archive_file()` functions
- Updated `PreviewState` with archive support

## Test plan
- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (286 passed)