### PR TITLE
release: v1.9.2 - Scroll bounds checking for previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2026-01-31
+
+### Fixed
+- **Scroll bounds checking**: Preview scroll now properly stops at the end of content
+  - `PreviewScrollDown` (j) stops at last line instead of scrolling infinitely
+  - `PreviewPageDown` (Ctrl+d) respects content boundaries
+  - `PreviewToBottom` (G) now syncs with ViewMode scroll state
+  - Applies to text, hex, and archive previews
+
+### Added
+- **Unit tests**: Added scroll bounds tests for all preview types
+
 ## [1.9.1] - 2026-01-31
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.9.1"
+version = "1.9.2"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/handler/action/display.rs
+++ b/src/handler/action/display.rs
@@ -157,13 +157,16 @@ pub fn handle_preview_scroll(
         }
         KeyAction::PreviewScrollDown => {
             if let Some(ref mut tp) = text_preview {
-                tp.scroll += 1;
+                let max_scroll = tp.lines.len().saturating_sub(1);
+                tp.scroll = (tp.scroll + 1).min(max_scroll);
             }
             if let Some(ref mut hp) = hex_preview {
-                hp.scroll += 1;
+                let max_scroll = hp.line_count().saturating_sub(1);
+                hp.scroll = (hp.scroll + 1).min(max_scroll);
             }
             if let Some(ref mut ap) = archive_preview {
-                ap.scroll += 1;
+                let max_scroll = ap.line_count().saturating_sub(1);
+                ap.scroll = (ap.scroll + 1).min(max_scroll);
             }
             if let ViewMode::Preview { scroll } = &mut state.mode {
                 *scroll += 1;
@@ -185,13 +188,16 @@ pub fn handle_preview_scroll(
         }
         KeyAction::PreviewPageDown => {
             if let Some(ref mut tp) = text_preview {
-                tp.scroll += 20;
+                let max_scroll = tp.lines.len().saturating_sub(1);
+                tp.scroll = (tp.scroll + 20).min(max_scroll);
             }
             if let Some(ref mut hp) = hex_preview {
-                hp.scroll += 20;
+                let max_scroll = hp.line_count().saturating_sub(1);
+                hp.scroll = (hp.scroll + 20).min(max_scroll);
             }
             if let Some(ref mut ap) = archive_preview {
-                ap.scroll += 20;
+                let max_scroll = ap.line_count().saturating_sub(1);
+                ap.scroll = (ap.scroll + 20).min(max_scroll);
             }
             if let ViewMode::Preview { scroll } = &mut state.mode {
                 *scroll += 20;
@@ -213,13 +219,23 @@ pub fn handle_preview_scroll(
         }
         KeyAction::PreviewToBottom => {
             if let Some(ref mut tp) = text_preview {
-                tp.scroll = tp.lines.len().saturating_sub(20);
+                tp.scroll = tp.lines.len().saturating_sub(1);
             }
             if let Some(ref mut hp) = hex_preview {
-                hp.scroll = hp.line_count().saturating_sub(20);
+                hp.scroll = hp.line_count().saturating_sub(1);
             }
             if let Some(ref mut ap) = archive_preview {
-                ap.scroll = ap.line_count().saturating_sub(20);
+                ap.scroll = ap.line_count().saturating_sub(1);
+            }
+            if let ViewMode::Preview { scroll } = &mut state.mode {
+                // Set to max for ViewMode as well
+                if let Some(ref tp) = text_preview {
+                    *scroll = tp.lines.len().saturating_sub(1);
+                } else if let Some(ref hp) = hex_preview {
+                    *scroll = hp.line_count().saturating_sub(1);
+                } else if let Some(ref ap) = archive_preview {
+                    *scroll = ap.line_count().saturating_sub(1);
+                }
             }
         }
         _ => {}


### PR DESCRIPTION
## Summary
- Fix scroll bounds checking for preview panels
- `PreviewScrollDown` (j) now stops at last line instead of scrolling infinitely
- `PreviewPageDown` (Ctrl+d) respects content boundaries
- `PreviewToBottom` (G) now syncs with ViewMode scroll state
- Applies to text, hex, and archive previews

## Test Plan
- [x] `cargo check` passed
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` passed (294 tests)

## Manual Testing
- [ ] 長いファイルで j を連打してスクロールが止まることを確認
- [ ] Ctrl+d で最後までスクロールできることを確認
- [ ] G で最下部へジャンプできることを確認