### PR TITLE
release: v1.10.0 - Add tar.gz archive preview support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2026-01-31
+
+### Fixed
+- **Scroll bounds checking**: Preview scroll now properly stops at the end of content
+  - `PreviewScrollDown` (j) stops at last line instead of scrolling infinitely
+  - `PreviewPageDown` (Ctrl+d) respects content boundaries
+  - `PreviewToBottom` (G) now syncs with ViewMode scroll state
+  - Applies to text, hex, and archive previews
+
+### Added
+- **Unit tests**: Added scroll bounds tests for all preview types
+
 ## [1.9.1] - 2026-01-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2026-01-31
+
+### Added
+- **tar.gz archive support**: Preview contents of tar.gz archives
+  - Supported extensions: `.tar.gz`, `.tgz`
+  - Shows file list with sizes and dates
+  - Same sorting as zip archives (directories first)
+
+### Dependencies
+- Added `tar` crate (v0.4) for tar archive reading
+- Added `flate2` crate (v1.0) for gzip decompression
+
 ## [1.9.2] - 2026-01-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,13 +828,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "fileview"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "anyhow",
  "arboard",
  "assert_cmd",
  "crossterm",
+ "flate2",
  "image",
  "notify",
  "notify-debouncer-mini",
@@ -842,6 +854,7 @@ dependencies = [
  "predicates",
  "ratatui",
  "ratatui-image",
+ "tar",
  "tempfile",
  "zip",
 ]
@@ -1241,6 +1254,17 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "redox_syscall 0.7.0",
+]
 
 [[package]]
 name = "line-clipping"
@@ -1712,7 +1736,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2253,6 +2277,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,6 +2605,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"
@@ -3276,6 +3320,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.3",
+]
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.9.2"
+version = "1.10.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]
@@ -31,6 +31,8 @@ nucleo-matcher = "0.3"
 notify = "8.2"
 notify-debouncer-mini = "0.6"
 zip = "2.4"
+tar = "0.4"
+flate2 = "1.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.9.1"
+version = "1.9.2"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/app/preview.rs
+++ b/src/app/preview.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use crate::core::AppState;
 use crate::render::{
-    is_archive_file, is_binary_file, is_image_file, is_text_file, ArchivePreview, DirectoryInfo,
-    HexPreview, ImagePreview, Picker, TextPreview,
+    is_archive_file, is_binary_file, is_image_file, is_tar_gz_file, is_text_file, ArchivePreview,
+    DirectoryInfo, HexPreview, ImagePreview, Picker, TextPreview,
 };
 
 /// Preview state container
@@ -89,6 +89,21 @@ impl PreviewState {
                         state.set_message(format!("Failed: preview - {}", e));
                         self.clear_all();
                     }
+                }
+            }
+        } else if is_tar_gz_file(path) {
+            // Handle tar.gz files separately (before is_archive_file check)
+            match ArchivePreview::load_tar_gz(path) {
+                Ok(archive) => {
+                    self.archive = Some(archive);
+                    self.text = None;
+                    self.image = None;
+                    self.dir_info = None;
+                    self.hex = None;
+                }
+                Err(e) => {
+                    state.set_message(format!("Failed: preview - {}", e));
+                    self.clear_all();
                 }
             }
         } else if is_archive_file(path) {

--- a/src/handler/action/display.rs
+++ b/src/handler/action/display.rs
@@ -157,13 +157,16 @@ pub fn handle_preview_scroll(
         }
         KeyAction::PreviewScrollDown => {
             if let Some(ref mut tp) = text_preview {
-                tp.scroll += 1;
+                let max_scroll = tp.lines.len().saturating_sub(1);
+                tp.scroll = (tp.scroll + 1).min(max_scroll);
             }
             if let Some(ref mut hp) = hex_preview {
-                hp.scroll += 1;
+                let max_scroll = hp.line_count().saturating_sub(1);
+                hp.scroll = (hp.scroll + 1).min(max_scroll);
             }
             if let Some(ref mut ap) = archive_preview {
-                ap.scroll += 1;
+                let max_scroll = ap.line_count().saturating_sub(1);
+                ap.scroll = (ap.scroll + 1).min(max_scroll);
             }
             if let ViewMode::Preview { scroll } = &mut state.mode {
                 *scroll += 1;
@@ -185,13 +188,16 @@ pub fn handle_preview_scroll(
         }
         KeyAction::PreviewPageDown => {
             if let Some(ref mut tp) = text_preview {
-                tp.scroll += 20;
+                let max_scroll = tp.lines.len().saturating_sub(1);
+                tp.scroll = (tp.scroll + 20).min(max_scroll);
             }
             if let Some(ref mut hp) = hex_preview {
-                hp.scroll += 20;
+                let max_scroll = hp.line_count().saturating_sub(1);
+                hp.scroll = (hp.scroll + 20).min(max_scroll);
             }
             if let Some(ref mut ap) = archive_preview {
-                ap.scroll += 20;
+                let max_scroll = ap.line_count().saturating_sub(1);
+                ap.scroll = (ap.scroll + 20).min(max_scroll);
             }
             if let ViewMode::Preview { scroll } = &mut state.mode {
                 *scroll += 20;
@@ -213,13 +219,23 @@ pub fn handle_preview_scroll(
         }
         KeyAction::PreviewToBottom => {
             if let Some(ref mut tp) = text_preview {
-                tp.scroll = tp.lines.len().saturating_sub(20);
+                tp.scroll = tp.lines.len().saturating_sub(1);
             }
             if let Some(ref mut hp) = hex_preview {
-                hp.scroll = hp.line_count().saturating_sub(20);
+                hp.scroll = hp.line_count().saturating_sub(1);
             }
             if let Some(ref mut ap) = archive_preview {
-                ap.scroll = ap.line_count().saturating_sub(20);
+                ap.scroll = ap.line_count().saturating_sub(1);
+            }
+            if let ViewMode::Preview { scroll } = &mut state.mode {
+                // Set to max for ViewMode as well
+                if let Some(ref tp) = text_preview {
+                    *scroll = tp.lines.len().saturating_sub(1);
+                } else if let Some(ref hp) = hex_preview {
+                    *scroll = hp.line_count().saturating_sub(1);
+                } else if let Some(ref ap) = archive_preview {
+                    *scroll = ap.line_count().saturating_sub(1);
+                }
             }
         }
         _ => {}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -10,10 +10,10 @@ pub mod tree;
 pub use fuzzy::{collect_paths, fuzzy_match, render_fuzzy_finder, FuzzyMatch};
 pub use icons::get_icon;
 pub use preview::{
-    calculate_centered_image_area, is_archive_file, is_binary_file, is_image_file, is_text_file,
-    render_archive_preview, render_directory_info, render_hex_preview, render_image_preview,
-    render_text_preview, ArchiveEntry, ArchivePreview, DirectoryInfo, HexPreview, ImagePreview,
-    TextPreview,
+    calculate_centered_image_area, is_archive_file, is_binary_file, is_image_file, is_tar_gz_file,
+    is_text_file, render_archive_preview, render_directory_info, render_hex_preview,
+    render_image_preview, render_text_preview, ArchiveEntry, ArchivePreview, DirectoryInfo,
+    HexPreview, ImagePreview, TextPreview,
 };
 pub use ratatui_image::picker::Picker;
 pub use ratatui_image::FontSize;


### PR DESCRIPTION
## Summary
- Add support for previewing `.tar.gz` and `.tgz` archive files
- Shows file list with sizes and dates (same UI as zip archives)
- Directories sorted first, then files alphabetically

## Dependencies
- Added `tar` crate (v0.4) for tar archive reading
- Added `flate2` crate (v1.0) for gzip decompression

## Test Plan
- [x] `cargo check` passed
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` passed (300 tests)

## Manual Testing
- [ ] `.tar.gz` ファイルを選択してプレビュー表示を確認
- [ ] `.tgz` ファイルを選択してプレビュー表示を確認
- [ ] ファイル一覧とサイズが正しく表示されることを確認

⚠️ **Note**: This PR depends on v1.9.2 being merged first (#83)