### PR TITLE
release: v1.11.2 - Add comprehensive mouse module tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.2] - 2026-01-31
+
+### Added
+- **Unit tests**: Added comprehensive tests for mouse module (29 new tests)
+  - ClickDetector: double-click detection, reset behavior, row tracking
+  - PathBuffer: buffer operations, path parsing, clear/take functionality
+  - normalize_shell_path: edge cases, special characters, URL encoding
+  - parse_paths: empty input, mixed valid/invalid paths
+  - handle_mouse_event: click, double-click, scroll, various button types
+
 ## [1.11.1] - 2026-01-31
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.11.1"
+version = "1.11.2"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]


### PR DESCRIPTION
## Summary
- Add 29 new tests for mouse module (42 total)

## Test Coverage
- **ClickDetector**: double-click detection, reset behavior, row tracking
- **PathBuffer**: buffer operations, path parsing, clear/take functionality
- **normalize_shell_path**: edge cases, special characters, URL encoding
- **parse_paths**: empty input, mixed valid/invalid paths
- **handle_mouse_event**: click, double-click, scroll, various button types

## Test plan
- [x] `cargo check` passed
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` passed (306 tests total, 29 new)