### PR TITLE
release: v1.12.0 - Security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2026-01-31
+
+### Security
+
+- **stdin path traversal fix**: `--stdin` mode now validates paths using `canonicalize()` to prevent path traversal attacks (e.g., `../../../etc/passwd`)
+- **git command PATH hardening**: Git executable is now resolved from standard system paths (`/usr/bin/git`, `/usr/local/bin/git`, `/opt/homebrew/bin/git`) before falling back to `$PATH`, preventing malicious git binary injection
+- **TOCTOU mitigation**: `get_unique_path()` now uses bounded counter (1-1000) with timestamp fallback to reduce race condition window during file copy operations
+
+### Added
+
+- **Security documentation**: New `docs/SECURITY.md` documenting security model and `--on-select` callback safety guidelines
+
 ## [1.11.3] - 2026-01-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.11.3"
+version = "1.12.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,37 @@
+# Security
+
+## Overview
+
+fileview (fv) is a file browser that runs with the user's permissions.
+
+## Security Model
+
+- Runs as the current user with their file permissions
+- No privilege escalation or network operations
+- File operations affect user's own filesystem
+
+## --on-select Callback
+
+The `--on-select` option executes shell commands. Security considerations:
+
+- Commands run with your shell and permissions
+- Paths are escaped using single-quote wrapping
+- Do NOT use with untrusted command strings
+- Equivalent to running commands manually in terminal
+
+### Safe Usage
+
+```bash
+fv --pick --on-select "code {}"      # Open in editor
+fv --pick --on-select "cat {}"       # Display file
+```
+
+### Unsafe (Avoid)
+
+```bash
+fv --on-select "$UNTRUSTED_VAR {}"   # Never use untrusted input
+```
+
+## Reporting Vulnerabilities
+
+Report security issues via GitHub Security Advisories or email.

--- a/tests/e2e/stdin_mode.rs
+++ b/tests/e2e/stdin_mode.rs
@@ -28,7 +28,7 @@ fn stdin_with_empty_input_returns_error() {
         .write_stdin("")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("No paths provided"));
+        .stderr(predicate::str::contains("No valid paths provided"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Security audit fixes:
- **stdin path traversal fix**: `--stdin` mode now validates paths using `canonicalize()` to prevent path traversal attacks
- **git command PATH hardening**: Git executable resolved from standard system paths before falling back to `$PATH`
- **TOCTOU mitigation**: `get_unique_path()` uses bounded counter with timestamp fallback

## Added

- `docs/SECURITY.md` - Security model documentation

## Test plan

- [x] `cargo check` - passed
- [x] `cargo fmt --all -- --check` - passed
- [x] `cargo clippy -- -D warnings` - passed
- [x] `cargo test` - passed (340 tests)