### PR TITLE
release: v1.14.2 - Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.2] - 2026-01-31
+
+### Fixed
+
+- **tar.gz date display**: Fixed incorrect date calculation in archive preview that didn't account for leap years and month lengths
+- **Bookmark key handling**: Replaced `unwrap()` with safe pattern matching for bookmark slot keys ('1'-'9')
+
 ## [1.14.1] - 2026-01-31
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.14.1"
+version = "1.14.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.14.1"
+version = "1.14.2"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/handler/key.rs
+++ b/src/handler/key.rs
@@ -477,8 +477,8 @@ pub fn create_delete_targets(state: &AppState, focused_path: Option<&PathBuf>) -
 /// Handle keys in bookmark set mode (waiting for slot number)
 fn handle_bookmark_set_mode(key: KeyEvent) -> KeyAction {
     match key.code {
-        KeyCode::Char(c) if c.is_ascii_digit() && c != '0' => {
-            let slot = c.to_digit(10).unwrap() as u8;
+        KeyCode::Char(c @ '1'..='9') => {
+            let slot = c as u8 - b'0';
             KeyAction::SetBookmark { slot }
         }
         // Same key to cancel (toggle behavior)
@@ -490,8 +490,8 @@ fn handle_bookmark_set_mode(key: KeyEvent) -> KeyAction {
 /// Handle keys in bookmark jump mode (waiting for slot number)
 fn handle_bookmark_jump_mode(key: KeyEvent) -> KeyAction {
     match key.code {
-        KeyCode::Char(c) if c.is_ascii_digit() && c != '0' => {
-            let slot = c.to_digit(10).unwrap() as u8;
+        KeyCode::Char(c @ '1'..='9') => {
+            let slot = c as u8 - b'0';
             KeyAction::JumpToBookmark { slot }
         }
         // Same key to cancel (toggle behavior)


### PR DESCRIPTION
## Summary

- Fix tar.gz archive date display (incorrect leap year/month handling)
- Replace `unwrap()` with safe pattern matching in bookmark key handling

## Changes

### Bug fixes

1. **tar.gz date calculation** (`src/render/preview.rs`)
   - Added `unix_timestamp_to_date()` helper with proper leap year calculation
   - Added `is_leap_year()` helper function
   - Replaces broken approximate calculation that assumed 365 days/year and 30 days/month

2. **Bookmark key handling** (`src/handler/key.rs`)
   - Changed from `c.to_digit(10).unwrap()` to `c @ '1'..='9'` pattern matching
   - Direct ASCII subtraction: `c as u8 - b'0'`

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (303 tests)