### PR TITLE
release: v1.14.3 - Security hardening and refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.3] - 2026-01-31
+
+### Security
+
+- **Archive DoS prevention**: Added 4KB limit for archive entry names to prevent memory exhaustion from malicious archives
+
+### Changed
+
+- **Code refactoring**: Extracted `get_border_style()` helper to eliminate 6 duplicated border styling blocks
+- **Code refactoring**: Added `truncate_entry_name()` helper for consistent entry name handling
+
 ## [1.14.2] - 2026-01-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.14.2"
+version = "1.14.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.14.2"
+version = "1.14.3"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]


### PR DESCRIPTION
## Summary

- Security: Archive entry name length limit (DoS prevention)
- Refactoring: Extract helper functions to reduce code duplication

## Changes

### Security
- Added `MAX_ENTRY_NAME_LEN = 4096` constant
- Added `truncate_entry_name()` to limit archive entry names
- Prevents memory exhaustion from malicious archives with extremely long paths

### Refactoring
- Added `get_border_style(focused: bool) -> Style` helper
- Replaced 6 duplicated border styling blocks with helper calls
- Net reduction: -4 lines (42 added, 46 removed)

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (303 tests)