### PR TITLE
release: v1.17.0 - Custom commands, Custom preview, Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2026-01-31
+
+### Added
+
+- **Custom commands system**: Define and execute shell commands via config
+  - Commands section in `config.toml`: `[commands]`
+  - Placeholder expansion: `$f` (file path), `$d` (directory), `$n` (filename), `$s` (stem), `$e` (extension), `$S` (selected files)
+  - Keymap binding with `command:name` syntax
+  - Example: `open = "open $f"`, `edit = "nvim $f"`
+- **Custom preview system**: External scripts for file preview
+  - Custom preview section in `config.toml`: `[preview.custom]`
+  - Extension-to-command mapping: `md = "glow -s dark $f"`, `json = "jq -C . $f"`
+  - Scroll support for custom preview output
+- **Documentation**: Comprehensive configuration guides
+  - `docs/CONFIGURATION.md`: Main configuration reference
+  - `docs/THEMES.md`: Theme customization guide
+  - `docs/COMMANDS.md`: Custom commands guide
+  - `examples/config.toml`, `examples/keymap.toml`, `examples/theme.toml`: Example files
+
+### New Files
+
+- `src/handler/action/command.rs`: Command execution logic (~120 lines)
+- `src/render/preview.rs`: Added `CustomPreview` struct and `render_custom_preview` function
+- `docs/CONFIGURATION.md`: Configuration guide
+- `docs/THEMES.md`: Theme customization guide
+- `docs/COMMANDS.md`: Custom commands guide
+- `examples/`: Example configuration files
+
+### Changed
+
+- `PreviewState` now includes custom preview support
+- `handle_action` signature updated to include custom preview parameter
+- `handle_preview_scroll` now handles custom preview scrolling
+- Added `Clone` derive to `CommandsConfig` and `PreviewConfig`
+- Exported `CommandsConfig` and `PreviewConfig` from `app` module
+
+### Tests
+
+- Added 16 new integration tests for custom commands and custom preview
+- Added 6 new E2E tests for config file parsing with new features
+- Total test count: 346 unit/integration tests + 72 E2E tests = 418 tests
+
 ## [1.16.0] - 2026-01-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.16.0"
+version = "1.17.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,130 @@
+# Custom Commands
+
+FileView allows you to define custom shell commands and bind them to keys.
+
+## Defining Commands
+
+Commands are defined in `~/.config/fileview/config.toml`:
+
+```toml
+[commands]
+open = "open $f"
+edit = "nvim $f"
+terminal = "cd $d && $SHELL"
+compress = "zip -r archive.zip $S"
+view = "less $f"
+```
+
+## Placeholders
+
+| Placeholder | Description | Example |
+|-------------|-------------|---------|
+| `$f` | Full file path | `/home/user/documents/file.txt` |
+| `$d` | Parent directory | `/home/user/documents` |
+| `$n` | Filename with extension | `file.txt` |
+| `$s` | Filename without extension (stem) | `file` |
+| `$e` | File extension only | `txt` |
+| `$S` | All selected files (quoted, space-separated) | `'/path/a.txt' '/path/b.txt'` |
+
+## Binding Commands to Keys
+
+In `~/.config/fileview/keymap.toml`:
+
+```toml
+[browse]
+"o" = "command:open"
+"e" = "command:edit"
+"T" = "command:terminal"
+```
+
+The `command:` prefix tells FileView to execute the named command.
+
+## Examples
+
+### Open with Default Application
+
+```toml
+[commands]
+open = "open $f"              # macOS
+# open = "xdg-open $f"        # Linux
+# open = "start $f"           # Windows
+```
+
+### Edit with Editor
+
+```toml
+[commands]
+edit = "nvim $f"
+# edit = "code $f"            # VS Code
+# edit = "vim $f"             # Vim
+```
+
+### Open Terminal in Directory
+
+```toml
+[commands]
+terminal = "cd $d && $SHELL"
+```
+
+### Archive Operations
+
+```toml
+[commands]
+compress = "zip -r archive.zip $S"
+extract = "unzip $f -d $d"
+```
+
+### File Operations
+
+```toml
+[commands]
+chmod_exec = "chmod +x $f"
+chown = "sudo chown $USER $S"
+```
+
+### View and Preview
+
+```toml
+[commands]
+view = "less $f"
+preview = "bat --style=plain $f"
+hex = "xxd $f | less"
+```
+
+### Git Operations
+
+```toml
+[commands]
+git_diff = "git diff $f"
+git_log = "git log --oneline $f"
+git_blame = "git blame $f | less"
+```
+
+### Media Operations
+
+```toml
+[commands]
+play = "mpv $f"
+convert = "ffmpeg -i $f ${s}_converted.mp4"
+```
+
+## Custom Preview
+
+You can also define custom preview commands for specific file extensions:
+
+```toml
+[preview.custom]
+md = "glow -s dark $f"
+json = "jq -C . $f"
+csv = "column -s, -t $f | head -50"
+yaml = "yq -C . $f"
+```
+
+These are automatically used when previewing files with matching extensions.
+
+## Tips
+
+- Commands are executed via the shell (`sh -c` on Unix, `cmd /C` on Windows)
+- Use `$S` for operations on multiple selected files
+- Complex commands can be written as shell scripts
+- Test commands in terminal first before binding them

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,94 @@
+# Configuration Guide
+
+FileView supports configuration through TOML files located in `~/.config/fileview/`.
+
+## Configuration Files
+
+| File | Description |
+|------|-------------|
+| `config.toml` | Main settings (general, preview, UI, performance) |
+| `keymap.toml` | Custom key bindings |
+| `theme.toml` | Color theme customization |
+
+## Main Configuration (`config.toml`)
+
+### General Settings
+
+```toml
+[general]
+show_hidden = false       # Show hidden files by default
+enable_icons = true       # Enable Nerd Font icons
+mouse_enabled = true      # Enable mouse support
+```
+
+### Preview Settings
+
+```toml
+[preview]
+hex_max_bytes = 4096         # Maximum bytes for hex preview
+max_archive_entries = 500    # Maximum entries for archive preview
+image_protocol = "auto"      # Image protocol: auto, sixel, kitty, iterm2, halfblocks, chafa
+
+# Custom preview commands (extension -> command)
+[preview.custom]
+md = "glow -s dark $f"       # Markdown with glow
+json = "jq -C . $f"          # JSON with jq
+csv = "column -s, -t $f | head -50"
+```
+
+### Performance Settings
+
+```toml
+[performance]
+git_poll_interval_secs = 5   # Git status polling interval
+```
+
+### UI Settings
+
+```toml
+[ui]
+show_size = true                    # Show file sizes in tree view
+show_permissions = false            # Show file permissions
+date_format = "%Y-%m-%d %H:%M"      # Date format (strftime-style)
+```
+
+### Custom Commands
+
+```toml
+[commands]
+# Define commands that can be bound to keys
+# Placeholders: $f (full path), $d (directory), $n (filename), $s (stem), $e (extension), $S (selected files)
+open = "open $f"
+edit = "nvim $f"
+terminal = "cd $d && $SHELL"
+compress = "zip -r archive.zip $S"
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `FILEVIEW_ICONS=0` | Disable icons |
+| `FILEVIEW_IMAGE_PROTOCOL` | Force image protocol |
+
+## CLI Arguments
+
+CLI arguments override config file settings:
+
+```
+--hidden, -a     Show hidden files
+--no-hidden      Hide hidden files
+--icons, -i      Enable icons
+--no-icons       Disable icons
+```
+
+## Configuration Priority
+
+1. CLI arguments (highest priority)
+2. Environment variables
+3. Configuration file (`~/.config/fileview/config.toml`)
+4. Default values (lowest priority)
+
+## Example Configuration
+
+See [examples/config.toml](../examples/config.toml) for a complete example.

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -1,0 +1,143 @@
+# Theme Customization
+
+FileView supports custom color themes via `~/.config/fileview/theme.toml`.
+
+## Theme File Structure
+
+```toml
+[colors]
+background = "default"    # Main background
+foreground = "white"      # Default text color
+selection = "blue"        # Selection highlight
+border = "gray"           # Border color
+
+[file_colors]
+directory = "blue"        # Directory color
+executable = "green"      # Executable file color
+symlink = "cyan"          # Symbolic link color
+archive = "red"           # Archive file color (.zip, .tar, etc.)
+image = "magenta"         # Image file color
+media = "magenta"         # Media file color
+
+[git_colors]
+modified = "yellow"       # Modified file
+staged = "green"          # Staged file
+untracked = "red"         # Untracked file
+conflict = "red"          # Conflict file
+```
+
+## Color Formats
+
+FileView supports multiple color formats:
+
+### Named Colors
+
+```toml
+foreground = "white"
+directory = "blue"
+modified = "yellow"
+```
+
+Available named colors:
+- `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`
+- `gray`, `grey` (dark gray)
+- `lightred`, `lightgreen`, `lightyellow`, `lightblue`, `lightmagenta`, `lightcyan`
+- `darkgray`, `darkgrey`
+- `default` (terminal default)
+- `reset` (reset to default)
+
+### Hex Colors
+
+```toml
+# Short form (#RGB)
+background = "#123"
+
+# Long form (#RRGGBB)
+foreground = "#ff5733"
+```
+
+### RGB Function
+
+```toml
+selection = "rgb(255, 87, 51)"
+```
+
+### 256-Color Palette
+
+```toml
+# Using color<N> or colorN syntax
+border = "color240"
+accent = "color33"
+
+# Or just the number
+dim = "245"
+```
+
+## Example Themes
+
+### Dark Theme (Default)
+
+```toml
+[colors]
+background = "default"
+foreground = "white"
+selection = "blue"
+border = "gray"
+
+[file_colors]
+directory = "blue"
+executable = "green"
+symlink = "cyan"
+
+[git_colors]
+modified = "yellow"
+staged = "green"
+untracked = "red"
+```
+
+### Light Theme
+
+```toml
+[colors]
+background = "#ffffff"
+foreground = "#1a1a1a"
+selection = "#0066cc"
+border = "#cccccc"
+
+[file_colors]
+directory = "#0066cc"
+executable = "#008800"
+symlink = "#008888"
+
+[git_colors]
+modified = "#cc6600"
+staged = "#008800"
+untracked = "#cc0000"
+```
+
+### Nord Theme
+
+```toml
+[colors]
+background = "#2e3440"
+foreground = "#eceff4"
+selection = "#5e81ac"
+border = "#4c566a"
+
+[file_colors]
+directory = "#81a1c1"
+executable = "#a3be8c"
+symlink = "#88c0d0"
+
+[git_colors]
+modified = "#ebcb8b"
+staged = "#a3be8c"
+untracked = "#bf616a"
+```
+
+## Tips
+
+- Use `default` for background to inherit terminal background
+- Use 256-color palette (`color0`-`color255`) for precise control
+- Hex colors provide the most flexibility
+- Test your theme in different terminal emulators for consistency

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,0 +1,64 @@
+# FileView Configuration Example
+# Copy this file to ~/.config/fileview/config.toml
+
+[general]
+# Show hidden files by default
+show_hidden = false
+
+# Enable Nerd Font icons (requires Nerd Font installed)
+enable_icons = true
+
+# Enable mouse support
+mouse_enabled = true
+
+[preview]
+# Maximum bytes to show in hex preview
+hex_max_bytes = 4096
+
+# Maximum entries to show in archive preview
+max_archive_entries = 500
+
+# Image protocol: auto, sixel, kitty, iterm2, halfblocks, chafa
+image_protocol = "auto"
+
+# Custom preview commands (extension -> command)
+# Use $f as placeholder for the file path
+[preview.custom]
+# Markdown with glow (requires: brew install glow)
+# md = "glow -s dark $f"
+
+# JSON with jq (requires: brew install jq)
+# json = "jq -C . $f"
+
+# CSV as table
+# csv = "column -s, -t $f | head -50"
+
+[performance]
+# Git status polling interval in seconds
+git_poll_interval_secs = 5
+
+[ui]
+# Show file sizes in tree view
+show_size = true
+
+# Show file permissions in tree view
+show_permissions = false
+
+# Date format (strftime-style)
+date_format = "%Y-%m-%d %H:%M"
+
+[commands]
+# Custom commands that can be bound to keys
+# Placeholders: $f (file path), $d (directory), $n (filename), $s (stem), $e (extension), $S (selected files)
+
+# Open with default application
+open = "open $f"
+
+# Edit with editor
+edit = "nvim $f"
+
+# Open terminal in directory
+terminal = "cd $d && $SHELL"
+
+# Create archive from selected files
+compress = "zip -r archive.zip $S"

--- a/examples/keymap.toml
+++ b/examples/keymap.toml
@@ -1,0 +1,144 @@
+# FileView Keymap Example
+# Copy this file to ~/.config/fileview/keymap.toml
+
+[browse]
+# Navigation
+"j" = "move_down"
+"k" = "move_up"
+"down" = "move_down"
+"up" = "move_up"
+"g" = "move_to_top"
+"G" = "move_to_bottom"
+
+# Tree operations
+"l" = "expand"
+"h" = "collapse"
+"right" = "expand"
+"left" = "collapse"
+"tab" = "expand"
+"backspace" = "collapse"
+"enter" = "toggle_expand"
+"L" = "expand_all"
+"H" = "collapse_all"
+
+# Selection and clipboard
+"space" = "toggle_mark"
+"y" = "copy"
+"d" = "cut"
+"p" = "paste"
+
+# File operations
+"a" = "new_file"
+"A" = "new_dir"
+"r" = "rename"
+"D" = "confirm_delete"
+"delete" = "confirm_delete"
+
+# Search and filter
+"/" = "start_search"
+"n" = "search_next"
+"N" = "search_prev"
+"ctrl+p" = "fuzzy_finder"
+"f" = "start_filter"
+"ctrl+f" = "clear_filter"
+
+# Display and preview
+"." = "toggle_hidden"
+"P" = "toggle_quick_preview"
+"o" = "open_preview"
+"c" = "copy_path"
+"C" = "copy_filename"
+"R" = "refresh"
+"F5" = "refresh"
+"?" = "show_help"
+"s" = "cycle_sort"
+
+# Focus
+"ctrl+h" = "focus_tree"
+"ctrl+l" = "focus_preview"
+
+# Exit
+"q" = "quit"
+"Q" = "quit_and_cd"
+"escape" = "cancel"
+
+# Bookmarks
+"m" = "start_bookmark_set"
+"'" = "start_bookmark_jump"
+
+# Git operations
+"+" = "git_stage"
+"-" = "git_unstage"
+
+# Bulk rename
+"ctrl+r" = "start_bulk_rename"
+
+# Tabs
+"ctrl+t" = "new_tab"
+"ctrl+w" = "close_tab"
+"ctrl+n" = "next_tab"
+"ctrl+b" = "prev_tab"
+
+# Custom commands (bind to your commands from config.toml)
+# "e" = "command:edit"
+# "O" = "command:open"
+# "T" = "command:terminal"
+
+[preview]
+# Preview navigation
+"j" = "scroll_down"
+"k" = "scroll_up"
+"down" = "scroll_down"
+"up" = "scroll_up"
+"ctrl+d" = "page_down"
+"ctrl+u" = "page_up"
+"g" = "to_top"
+"G" = "to_bottom"
+
+# PDF navigation
+"[" = "pdf_prev_page"
+"]" = "pdf_next_page"
+
+# Exit preview
+"q" = "cancel"
+"escape" = "cancel"
+"o" = "cancel"
+
+[input]
+# Input mode (search, rename, etc.)
+"escape" = "cancel"
+"enter" = "confirm"
+
+[confirm]
+# Confirmation dialogs
+"y" = "confirm"
+"n" = "cancel"
+"escape" = "cancel"
+
+[fuzzy]
+# Fuzzy finder
+"down" = "fuzzy_down"
+"ctrl+n" = "fuzzy_down"
+"ctrl+j" = "fuzzy_down"
+"up" = "fuzzy_up"
+"ctrl+p" = "fuzzy_up"
+"ctrl+k" = "fuzzy_up"
+"enter" = "fuzzy_confirm"
+"escape" = "cancel"
+
+[bookmark]
+# Bookmark mode (after pressing m or ')
+# Any single key sets/jumps to that bookmark slot
+"escape" = "cancel"
+
+[help]
+# Help screen
+"q" = "cancel"
+"escape" = "cancel"
+"?" = "cancel"
+
+[bulk_rename]
+# Bulk rename mode
+"tab" = "bulk_rename_next_field"
+"enter" = "execute_bulk_rename"
+"escape" = "cancel"

--- a/examples/theme.toml
+++ b/examples/theme.toml
@@ -1,0 +1,89 @@
+# FileView Theme Example
+# Copy this file to ~/.config/fileview/theme.toml
+
+# Color formats:
+# - Named: "blue", "green", "yellow", "red", "cyan", "magenta", "white", "gray"
+# - Hex short: "#fff", "#123"
+# - Hex long: "#ffffff", "#112233"
+# - RGB: "rgb(255, 255, 255)"
+# - 256-color: "color240", "245"
+# - Special: "default" (terminal default), "reset"
+
+[colors]
+# Main colors
+background = "default"
+foreground = "white"
+selection = "blue"
+border = "gray"
+
+[file_colors]
+# File type colors
+directory = "blue"
+executable = "green"
+symlink = "cyan"
+archive = "red"
+image = "magenta"
+media = "magenta"
+
+[git_colors]
+# Git status colors
+modified = "yellow"
+staged = "green"
+untracked = "red"
+conflict = "red"
+ignored = "gray"
+
+# ============================================================
+# Alternative themes (uncomment one to use)
+# ============================================================
+
+# --- Light Theme ---
+# [colors]
+# background = "#ffffff"
+# foreground = "#1a1a1a"
+# selection = "#0066cc"
+# border = "#cccccc"
+#
+# [file_colors]
+# directory = "#0066cc"
+# executable = "#008800"
+# symlink = "#008888"
+#
+# [git_colors]
+# modified = "#cc6600"
+# staged = "#008800"
+# untracked = "#cc0000"
+
+# --- Nord Theme ---
+# [colors]
+# background = "#2e3440"
+# foreground = "#eceff4"
+# selection = "#5e81ac"
+# border = "#4c566a"
+#
+# [file_colors]
+# directory = "#81a1c1"
+# executable = "#a3be8c"
+# symlink = "#88c0d0"
+#
+# [git_colors]
+# modified = "#ebcb8b"
+# staged = "#a3be8c"
+# untracked = "#bf616a"
+
+# --- Dracula Theme ---
+# [colors]
+# background = "#282a36"
+# foreground = "#f8f8f2"
+# selection = "#44475a"
+# border = "#6272a4"
+#
+# [file_colors]
+# directory = "#bd93f9"
+# executable = "#50fa7b"
+# symlink = "#8be9fd"
+#
+# [git_colors]
+# modified = "#ffb86c"
+# staged = "#50fa7b"
+# untracked = "#ff5555"

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 
-use super::config_file::ConfigFile;
+use super::config_file::{CommandsConfig, ConfigFile, PreviewConfig};
 use crate::integrate::{exit_code, Callback, OutputFormat};
 
 /// Application configuration from CLI args and config file
@@ -38,6 +38,10 @@ pub struct Config {
     pub show_permissions: bool,
     /// Date format string (from config file)
     pub date_format: String,
+    /// Custom commands configuration
+    pub commands: CommandsConfig,
+    /// Custom preview configuration
+    pub preview_custom: PreviewConfig,
 }
 
 impl Config {
@@ -141,11 +145,13 @@ impl Config {
             mouse_enabled: config_file.general.mouse_enabled,
             hex_max_bytes: config_file.preview.hex_max_bytes,
             max_archive_entries: config_file.preview.max_archive_entries,
-            image_protocol: config_file.preview.image_protocol,
+            image_protocol: config_file.preview.image_protocol.clone(),
             git_poll_interval: Duration::from_secs(config_file.performance.git_poll_interval_secs),
             show_size: config_file.ui.show_size,
             show_permissions: config_file.ui.show_permissions,
             date_format: config_file.ui.date_format,
+            commands: config_file.commands,
+            preview_custom: config_file.preview,
         })
     }
 }

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -107,6 +107,7 @@ pub fn run_app(
     let action_context = ActionContext {
         callback: config.callback.clone(),
         output_format: config.output_format,
+        commands: config.commands.clone(),
     };
 
     // Preview state
@@ -187,7 +188,12 @@ pub fn run_app(
         // Update preview if needed (side panel or fullscreen mode)
         let needs_preview = state.preview_visible || matches!(state.mode, ViewMode::Preview { .. });
         if needs_preview {
-            preview.update(focused_path.as_ref(), image_picker, &mut state);
+            preview.update_with_custom(
+                focused_path.as_ref(),
+                image_picker,
+                &mut state,
+                &config.preview_custom.custom,
+            );
         }
 
         // Adjust viewport before rendering
@@ -401,6 +407,7 @@ pub fn run_app(
                         &mut preview.archive,
                         &mut preview.pdf,
                         &mut preview.diff,
+                        &mut preview.custom,
                         image_picker,
                     )? {
                         ActionResult::Continue => {}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,7 +11,7 @@ mod preview;
 mod render;
 
 pub use config::Config;
-pub use config_file::ConfigFile;
+pub use config_file::{CommandsConfig, ConfigFile, PreviewConfig};
 pub use event_loop::{run_app, AppResult};
 pub use image_loader::ImageLoader;
 pub use preview::PreviewState;

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -9,10 +9,10 @@ use crate::app::PreviewState;
 use crate::core::{AppState, FocusTarget, ViewMode};
 use crate::handler::action::get_filename_str;
 use crate::render::{
-    render_archive_preview, render_bulk_rename_dialog, render_diff_preview, render_directory_info,
-    render_fuzzy_finder, render_help_popup, render_hex_preview, render_image_preview,
-    render_input_popup, render_pdf_preview, render_status_bar, render_text_preview, render_tree,
-    FontSize, FuzzyMatch, Picker,
+    render_archive_preview, render_bulk_rename_dialog, render_custom_preview, render_diff_preview,
+    render_directory_info, render_fuzzy_finder, render_help_popup, render_hex_preview,
+    render_image_preview, render_input_popup, render_pdf_preview, render_status_bar,
+    render_text_preview, render_tree, FontSize, FuzzyMatch, Picker,
 };
 use crate::tree::TreeEntry;
 
@@ -65,6 +65,8 @@ fn render_fullscreen_preview(
         render_directory_info(frame, di, size, false);
     } else if let Some(ref dp) = ctx.preview.diff {
         render_diff_preview(frame, dp, size, &title, false);
+    } else if let Some(ref cp) = ctx.preview.custom {
+        render_custom_preview(frame, cp, size, &title, false);
     } else if let Some(ref tp) = ctx.preview.text {
         render_text_preview(frame, tp, size, &title, false);
     } else if let Some(ref mut ip) = ctx.preview.image {
@@ -150,6 +152,8 @@ fn render_side_preview(
         render_directory_info(frame, di, area, preview_focused);
     } else if let Some(ref dp) = ctx.preview.diff {
         render_diff_preview(frame, dp, area, &title, preview_focused);
+    } else if let Some(ref cp) = ctx.preview.custom {
+        render_custom_preview(frame, cp, area, &title, preview_focused);
     } else if let Some(ref tp) = ctx.preview.text {
         render_text_preview(frame, tp, area, &title, preview_focused);
     } else if let Some(ref mut ip) = ctx.preview.image {

--- a/src/handler/action/command.rs
+++ b/src/handler/action/command.rs
@@ -1,0 +1,225 @@
+//! Custom command execution
+//!
+//! Executes user-defined shell commands with placeholder expansion.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::app::CommandsConfig;
+
+/// Result of command execution
+#[derive(Debug)]
+pub enum CommandResult {
+    /// Command executed successfully
+    Success(String),
+    /// Command failed
+    Error(String),
+    /// Command not found in config
+    NotFound,
+}
+
+/// Execute a custom command by name
+///
+/// # Arguments
+/// * `name` - The command name as defined in config
+/// * `config` - The commands configuration
+/// * `file_path` - The current file path for placeholder expansion
+/// * `selected_paths` - Selected file paths (for $S placeholder)
+pub fn execute_command(
+    name: &str,
+    config: &CommandsConfig,
+    file_path: Option<&Path>,
+    selected_paths: &[std::path::PathBuf],
+) -> CommandResult {
+    let template = match config.get(name) {
+        Some(t) => t,
+        None => return CommandResult::NotFound,
+    };
+
+    // Expand placeholders
+    let cmd = if let Some(path) = file_path {
+        let mut expanded = CommandsConfig::expand(template, path);
+
+        // Handle $S (selected files) - join paths with spaces, quoted
+        if expanded.contains("$S") {
+            let selected: Vec<String> = selected_paths
+                .iter()
+                .map(|p| format!("'{}'", p.display()))
+                .collect();
+            expanded = expanded.replace("$S", &selected.join(" "));
+        }
+
+        expanded
+    } else {
+        template.clone()
+    };
+
+    // Execute command via shell
+    let output = if cfg!(target_os = "windows") {
+        Command::new("cmd").args(["/C", &cmd]).output()
+    } else {
+        Command::new("sh").args(["-c", &cmd]).output()
+    };
+
+    match output {
+        Ok(output) => {
+            if output.status.success() {
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                CommandResult::Success(stdout)
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                CommandResult::Error(if stderr.is_empty() {
+                    format!("Command failed with exit code: {:?}", output.status.code())
+                } else {
+                    stderr
+                })
+            }
+        }
+        Err(e) => CommandResult::Error(format!("Failed to execute command: {}", e)),
+    }
+}
+
+/// Execute a command and wait for it to complete (for TUI restoration)
+///
+/// This spawns the command in a way that allows it to take over the terminal,
+/// useful for commands like editors or pagers.
+pub fn execute_interactive(
+    name: &str,
+    config: &CommandsConfig,
+    file_path: Option<&Path>,
+) -> CommandResult {
+    let template = match config.get(name) {
+        Some(t) => t,
+        None => return CommandResult::NotFound,
+    };
+
+    let cmd = if let Some(path) = file_path {
+        CommandsConfig::expand(template, path)
+    } else {
+        template.clone()
+    };
+
+    // For interactive commands, we need to spawn and wait
+    let status = if cfg!(target_os = "windows") {
+        Command::new("cmd").args(["/C", &cmd]).status()
+    } else {
+        Command::new("sh").args(["-c", &cmd]).status()
+    };
+
+    match status {
+        Ok(status) => {
+            if status.success() {
+                CommandResult::Success(String::new())
+            } else {
+                CommandResult::Error(format!("Command exited with: {:?}", status.code()))
+            }
+        }
+        Err(e) => CommandResult::Error(format!("Failed to execute command: {}", e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn create_config(commands: Vec<(&str, &str)>) -> CommandsConfig {
+        let mut map = HashMap::new();
+        for (name, cmd) in commands {
+            map.insert(name.to_string(), cmd.to_string());
+        }
+        CommandsConfig { commands: map }
+    }
+
+    #[test]
+    fn test_command_not_found() {
+        let config = create_config(vec![]);
+        let result = execute_command("nonexistent", &config, None, &[]);
+        assert!(matches!(result, CommandResult::NotFound));
+    }
+
+    #[test]
+    fn test_simple_command() {
+        let config = create_config(vec![("echo_test", "echo hello")]);
+        let result = execute_command("echo_test", &config, None, &[]);
+        match result {
+            CommandResult::Success(output) => {
+                assert!(output.contains("hello"));
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+
+    #[test]
+    fn test_placeholder_expansion() {
+        let config = create_config(vec![("show_path", "echo $f")]);
+        let path = PathBuf::from("/tmp/test.txt");
+        let result = execute_command("show_path", &config, Some(&path), &[]);
+        match result {
+            CommandResult::Success(output) => {
+                assert!(output.contains("/tmp/test.txt"));
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+
+    #[test]
+    fn test_directory_placeholder() {
+        let config = create_config(vec![("show_dir", "echo $d")]);
+        let path = PathBuf::from("/tmp/test.txt");
+        let result = execute_command("show_dir", &config, Some(&path), &[]);
+        match result {
+            CommandResult::Success(output) => {
+                assert!(output.contains("/tmp"));
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+
+    #[test]
+    fn test_filename_placeholder() {
+        let config = create_config(vec![("show_name", "echo $n")]);
+        let path = PathBuf::from("/tmp/test.txt");
+        let result = execute_command("show_name", &config, Some(&path), &[]);
+        match result {
+            CommandResult::Success(output) => {
+                assert!(output.contains("test.txt"));
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+
+    #[test]
+    fn test_stem_placeholder() {
+        let config = create_config(vec![("show_stem", "echo $s")]);
+        let path = PathBuf::from("/tmp/test.txt");
+        let result = execute_command("show_stem", &config, Some(&path), &[]);
+        match result {
+            CommandResult::Success(output) => {
+                assert!(output.contains("test"));
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+
+    #[test]
+    fn test_extension_placeholder() {
+        let config = create_config(vec![("show_ext", "echo $e")]);
+        let path = PathBuf::from("/tmp/test.txt");
+        let result = execute_command("show_ext", &config, Some(&path), &[]);
+        match result {
+            CommandResult::Success(output) => {
+                assert!(output.contains("txt"));
+            }
+            _ => panic!("Expected success"),
+        }
+    }
+
+    #[test]
+    fn test_failed_command() {
+        let config = create_config(vec![("bad_cmd", "exit 1")]);
+        let result = execute_command("bad_cmd", &config, None, &[]);
+        assert!(matches!(result, CommandResult::Error(_)));
+    }
+}

--- a/src/handler/action/display.rs
+++ b/src/handler/action/display.rs
@@ -7,7 +7,9 @@ use std::path::PathBuf;
 use crate::core::{AppState, ViewMode};
 use crate::handler::key::KeyAction;
 use crate::integrate::{exit_code, PickResult};
-use crate::render::{ArchivePreview, DiffPreview, HexPreview, PdfPreview, Picker, TextPreview};
+use crate::render::{
+    ArchivePreview, CustomPreview, DiffPreview, HexPreview, PdfPreview, Picker, TextPreview,
+};
 use crate::tree::TreeNavigator;
 
 use super::{get_filename_str, reload_tree, ActionContext, ActionResult};
@@ -132,7 +134,7 @@ pub fn handle(
     Ok(())
 }
 
-/// Handle preview scroll actions for text, hex, archive, and diff previews
+/// Handle preview scroll actions for text, hex, archive, diff, and custom previews
 pub fn handle_preview_scroll(
     action: KeyAction,
     state: &mut AppState,
@@ -140,6 +142,7 @@ pub fn handle_preview_scroll(
     hex_preview: &mut Option<HexPreview>,
     archive_preview: &mut Option<ArchivePreview>,
     diff_preview: &mut Option<DiffPreview>,
+    custom_preview: &mut Option<CustomPreview>,
 ) {
     match action {
         KeyAction::PreviewScrollUp => {
@@ -154,6 +157,9 @@ pub fn handle_preview_scroll(
             }
             if let Some(ref mut dp) = diff_preview {
                 dp.scroll = dp.scroll.saturating_sub(1);
+            }
+            if let Some(ref mut cp) = custom_preview {
+                cp.scroll = cp.scroll.saturating_sub(1);
             }
             if let ViewMode::Preview { scroll } = &mut state.mode {
                 *scroll = scroll.saturating_sub(1);
@@ -176,6 +182,10 @@ pub fn handle_preview_scroll(
                 let max_scroll = dp.line_count().saturating_sub(1);
                 dp.scroll = (dp.scroll + 1).min(max_scroll);
             }
+            if let Some(ref mut cp) = custom_preview {
+                let max_scroll = cp.line_count().saturating_sub(1);
+                cp.scroll = (cp.scroll + 1).min(max_scroll);
+            }
             if let ViewMode::Preview { scroll } = &mut state.mode {
                 *scroll += 1;
             }
@@ -192,6 +202,9 @@ pub fn handle_preview_scroll(
             }
             if let Some(ref mut dp) = diff_preview {
                 dp.scroll = dp.scroll.saturating_sub(20);
+            }
+            if let Some(ref mut cp) = custom_preview {
+                cp.scroll = cp.scroll.saturating_sub(20);
             }
             if let ViewMode::Preview { scroll } = &mut state.mode {
                 *scroll = scroll.saturating_sub(20);
@@ -214,6 +227,10 @@ pub fn handle_preview_scroll(
                 let max_scroll = dp.line_count().saturating_sub(1);
                 dp.scroll = (dp.scroll + 20).min(max_scroll);
             }
+            if let Some(ref mut cp) = custom_preview {
+                let max_scroll = cp.line_count().saturating_sub(1);
+                cp.scroll = (cp.scroll + 20).min(max_scroll);
+            }
             if let ViewMode::Preview { scroll } = &mut state.mode {
                 *scroll += 20;
             }
@@ -230,6 +247,9 @@ pub fn handle_preview_scroll(
             }
             if let Some(ref mut dp) = diff_preview {
                 dp.scroll = 0;
+            }
+            if let Some(ref mut cp) = custom_preview {
+                cp.scroll = 0;
             }
             if let ViewMode::Preview { scroll } = &mut state.mode {
                 *scroll = 0;
@@ -248,6 +268,9 @@ pub fn handle_preview_scroll(
             if let Some(ref mut dp) = diff_preview {
                 dp.scroll = dp.line_count().saturating_sub(1);
             }
+            if let Some(ref mut cp) = custom_preview {
+                cp.scroll = cp.line_count().saturating_sub(1);
+            }
             if let ViewMode::Preview { scroll } = &mut state.mode {
                 // Set to max for ViewMode as well
                 if let Some(ref tp) = text_preview {
@@ -258,6 +281,8 @@ pub fn handle_preview_scroll(
                     *scroll = ap.line_count().saturating_sub(1);
                 } else if let Some(ref dp) = diff_preview {
                     *scroll = dp.line_count().saturating_sub(1);
+                } else if let Some(ref cp) = custom_preview {
+                    *scroll = cp.line_count().saturating_sub(1);
                 }
             }
         }

--- a/src/handler/action/tests.rs
+++ b/src/handler/action/tests.rs
@@ -8,7 +8,8 @@ use crate::core::{AppState, FocusTarget, ViewMode};
 use crate::handler::key::KeyAction;
 use crate::integrate::exit_code;
 use crate::render::{
-    ArchiveEntry, ArchivePreview, DiffPreview, HexPreview, PdfPreview, Picker, TextPreview,
+    ArchiveEntry, ArchivePreview, CustomPreview, DiffPreview, HexPreview, PdfPreview, Picker,
+    TextPreview,
 };
 use crate::tree::TreeNavigator;
 
@@ -23,6 +24,7 @@ macro_rules! call_handle_action {
      $text_preview:expr, $hex_preview:expr, $archive_preview:expr) => {{
         let mut pdf_preview: Option<PdfPreview> = None;
         let mut diff_preview: Option<DiffPreview> = None;
+        let mut custom_preview: Option<CustomPreview> = None;
         let mut image_picker: Option<Picker> = None;
         handle_action(
             $action,
@@ -36,6 +38,7 @@ macro_rules! call_handle_action {
             $archive_preview,
             &mut pdf_preview,
             &mut diff_preview,
+            &mut custom_preview,
             &mut image_picker,
         )
     }};

--- a/src/handler/key.rs
+++ b/src/handler/key.rs
@@ -146,6 +146,8 @@ pub enum KeyAction {
     NextTab,
     /// Switch to the previous tab
     PrevTab,
+    /// Run a custom command
+    RunCommand { name: String },
 }
 
 /// Handle key event and return the resulting action

--- a/src/handler/keymap.rs
+++ b/src/handler/keymap.rs
@@ -430,7 +430,14 @@ fn parse_browse_action(action: &str) -> Option<KeyAction> {
         "preview_page_down" | "preview_page_down_if_preview" => Some(KeyAction::PreviewPageDown),
         "preview_to_top" => Some(KeyAction::PreviewToTop),
         "preview_to_bottom" => Some(KeyAction::PreviewToBottom),
-        _ => None,
+        _ => {
+            // Check for command:name pattern
+            action
+                .strip_prefix("command:")
+                .map(|name| KeyAction::RunCommand {
+                    name: name.to_string(),
+                })
+        }
     }
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -15,10 +15,10 @@ pub use fuzzy::{collect_paths, fuzzy_match, render_fuzzy_finder, FuzzyMatch};
 pub use icons::get_icon;
 pub use preview::{
     calculate_centered_image_area, find_pdftoppm, is_archive_file, is_binary_file, is_image_file,
-    is_pdf_file, is_tar_gz_file, is_text_file, render_archive_preview, render_diff_preview,
-    render_directory_info, render_hex_preview, render_image_preview, render_pdf_preview,
-    render_text_preview, ArchiveEntry, ArchivePreview, DiffPreview, DirectoryInfo, HexPreview,
-    ImagePreview, PdfPreview, TextPreview,
+    is_pdf_file, is_tar_gz_file, is_text_file, render_archive_preview, render_custom_preview,
+    render_diff_preview, render_directory_info, render_hex_preview, render_image_preview,
+    render_pdf_preview, render_text_preview, ArchiveEntry, ArchivePreview, CustomPreview,
+    DiffPreview, DirectoryInfo, HexPreview, ImagePreview, PdfPreview, TextPreview,
 };
 pub use ratatui_image::picker::Picker;
 pub use ratatui_image::FontSize;

--- a/src/render/preview.rs
+++ b/src/render/preview.rs
@@ -1351,6 +1351,86 @@ pub fn render_diff_preview(
     frame.render_widget(widget, area);
 }
 
+/// Custom preview content from external command
+pub struct CustomPreview {
+    /// Output lines from the command
+    pub lines: Vec<String>,
+    /// The command that was executed
+    pub command: String,
+    /// Scroll position
+    pub scroll: usize,
+}
+
+impl CustomPreview {
+    /// Execute a custom preview command and capture output
+    ///
+    /// The command template can use $f as a placeholder for the file path.
+    pub fn execute(command_template: &str, file_path: &std::path::Path) -> anyhow::Result<Self> {
+        use std::process::Command;
+
+        // Expand $f placeholder
+        let cmd = command_template.replace("$f", &file_path.display().to_string());
+
+        // Execute command via shell
+        let output = if cfg!(target_os = "windows") {
+            Command::new("cmd").args(["/C", &cmd]).output()
+        } else {
+            Command::new("sh").args(["-c", &cmd]).output()
+        }?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let lines: Vec<String> = stdout.lines().map(String::from).collect();
+
+        Ok(Self {
+            lines,
+            command: cmd,
+            scroll: 0,
+        })
+    }
+
+    /// Get the total number of lines
+    pub fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+}
+
+/// Render custom preview output
+pub fn render_custom_preview(
+    frame: &mut Frame,
+    preview: &CustomPreview,
+    area: Rect,
+    title: &str,
+    focused: bool,
+) {
+    let visible_height = area.height.saturating_sub(2) as usize;
+    let start = preview.scroll;
+    let end = (start + visible_height).min(preview.lines.len());
+
+    let lines: Vec<Line> = preview.lines[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, line)| {
+            let line_num = start + i + 1;
+            Line::from(vec![
+                Span::styled(
+                    format!("{:4} ", line_num),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::raw(line.as_str()),
+            ])
+        })
+        .collect();
+
+    let widget = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" {} ", title))
+            .border_style(get_border_style(focused)),
+    );
+
+    frame.render_widget(widget, area);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- **Custom commands system**: Define and execute shell commands via `[commands]` section
  - Placeholder expansion: `$f`, `$d`, `$n`, `$s`, `$e`, `$S`
  - Keymap binding with `command:name` syntax
- **Custom preview system**: Extension-based external preview scripts via `[preview.custom]`
  - Example: `md = "glow -s dark $f"`, `json = "jq -C . $f"`
- **Documentation**: Comprehensive configuration guides
  - `docs/CONFIGURATION.md`, `docs/THEMES.md`, `docs/COMMANDS.md`
  - Example files in `examples/`

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (346 unit/integration + 72 E2E = 418 tests)
- [x] New integration tests for custom commands (10 tests)
- [x] New integration tests for custom preview (6 tests)
- [x] New E2E tests for config parsing (6 tests)