### PR TITLE
release: v1.19.0 - Lua plugin system (Phase 12a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-02-03
+
+### Added
+
+- **Lua plugin system (Phase 12a)**: Scripting support via Lua 5.4
+  - Plugin location: `~/.config/fileview/plugins/init.lua`
+  - Uses `mlua` crate with vendored Lua 5.4
+  - Read-only API for accessing FileView state:
+    - `fv.current_file()`: Get currently focused file path
+    - `fv.current_dir()`: Get current directory path
+    - `fv.selected_files()`: Get list of selected files
+    - `fv.notify(msg)`: Display notification message
+    - `fv.version()`: Get FileView version
+    - `fv.is_dir(path)`: Check if path is directory
+    - `fv.file_exists(path)`: Check if path exists
+
+### New Files
+
+- `src/plugin/mod.rs`: Plugin system module entry (~30 lines)
+- `src/plugin/lua.rs`: Lua runtime management and API setup (~280 lines)
+- `src/plugin/api.rs`: Plugin context for state sharing (~100 lines)
+
+### Dependencies
+
+- Added `mlua = { version = "0.10", features = ["lua54", "vendored"] }`
+
+### Tests
+
+- Added 18 new unit tests for plugin module
+- Total test count: 436 tests (346 unit + 72 E2E + 18 plugin)
+
+### Documentation
+
+- Added `docs/ROADMAP_V4.md`: Future development roadmap for v4+ features
+
 ## [1.18.0] - 2026-02-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -905,6 +911,7 @@ dependencies = [
  "dirs",
  "flate2",
  "image",
+ "mlua",
  "notify",
  "notify-debouncer-mini",
  "nucleo-matcher",
@@ -1418,6 +1425,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lua-src"
+version = "547.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.5.12+a4f56a4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "lzma-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1531,34 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mlua"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f5f8fbebc7db5f671671134b9321c4b9aa9adeafccfd9a8c020ae45c6a35d0"
+dependencies = [
+ "bstr",
+ "either",
+ "mlua-sys",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash",
+ "rustversion",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "lua-src",
+ "luajit-src",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2493,6 +2547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3295,6 +3355,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.1.3",
+ "winsafe",
+]
+
+[[package]]
 name = "wide"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,6 +3760,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.18.0"
+version = "1.19.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]
@@ -39,6 +39,7 @@ flate2 = "1.0"
 trash = "5"
 tempfile = "3"
 syntect = "5"
+mlua = { version = "0.10", features = ["lua54", "vendored"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod core;
 pub mod git;
 pub mod handler;
 pub mod integrate;
+pub mod plugin;
 pub mod render;
 pub mod tree;
 pub mod watcher;

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -1,0 +1,138 @@
+//! Plugin API context
+//!
+//! This module provides the context that plugins can access to interact
+//! with FileView's current state.
+
+use std::path::PathBuf;
+
+/// Context shared between FileView and Lua plugins
+///
+/// This structure holds the current state that plugins can read and
+/// provides a way for plugins to communicate back to FileView.
+#[derive(Debug, Default)]
+pub struct PluginContext {
+    /// Currently focused file path (None if directory or no focus)
+    current_file: Option<PathBuf>,
+    /// Current directory path
+    current_dir: PathBuf,
+    /// Currently selected files (multi-select)
+    selected_files: Vec<PathBuf>,
+    /// Pending notifications from plugins
+    notifications: Vec<String>,
+}
+
+impl PluginContext {
+    /// Create a new empty context
+    pub fn new() -> Self {
+        Self {
+            current_file: None,
+            current_dir: PathBuf::new(),
+            selected_files: Vec::new(),
+            notifications: Vec::new(),
+        }
+    }
+
+    /// Get the currently focused file path
+    pub fn current_file(&self) -> Option<&PathBuf> {
+        self.current_file.as_ref()
+    }
+
+    /// Set the currently focused file
+    pub fn set_current_file(&mut self, path: Option<PathBuf>) {
+        self.current_file = path;
+    }
+
+    /// Get the current directory
+    pub fn current_dir(&self) -> &PathBuf {
+        &self.current_dir
+    }
+
+    /// Set the current directory
+    pub fn set_current_dir(&mut self, path: PathBuf) {
+        self.current_dir = path;
+    }
+
+    /// Get the selected files
+    pub fn selected_files(&self) -> &[PathBuf] {
+        &self.selected_files
+    }
+
+    /// Set the selected files
+    pub fn set_selected_files(&mut self, paths: Vec<PathBuf>) {
+        self.selected_files = paths;
+    }
+
+    /// Add a notification message
+    pub fn add_notification(&mut self, msg: String) {
+        self.notifications.push(msg);
+    }
+
+    /// Take all pending notifications
+    pub fn take_notifications(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.notifications)
+    }
+
+    /// Check if there are pending notifications
+    pub fn has_notifications(&self) -> bool {
+        !self.notifications.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_new() {
+        let ctx = PluginContext::new();
+        assert!(ctx.current_file().is_none());
+        assert!(ctx.current_dir().as_os_str().is_empty());
+        assert!(ctx.selected_files().is_empty());
+        assert!(!ctx.has_notifications());
+    }
+
+    #[test]
+    fn test_set_current_file() {
+        let mut ctx = PluginContext::new();
+        ctx.set_current_file(Some(PathBuf::from("/test/file.txt")));
+        assert_eq!(ctx.current_file(), Some(&PathBuf::from("/test/file.txt")));
+
+        ctx.set_current_file(None);
+        assert!(ctx.current_file().is_none());
+    }
+
+    #[test]
+    fn test_set_current_dir() {
+        let mut ctx = PluginContext::new();
+        ctx.set_current_dir(PathBuf::from("/test/dir"));
+        assert_eq!(ctx.current_dir(), &PathBuf::from("/test/dir"));
+    }
+
+    #[test]
+    fn test_selected_files() {
+        let mut ctx = PluginContext::new();
+        let files = vec![PathBuf::from("/a.txt"), PathBuf::from("/b.txt")];
+        ctx.set_selected_files(files.clone());
+        assert_eq!(ctx.selected_files(), files.as_slice());
+    }
+
+    #[test]
+    fn test_notifications() {
+        let mut ctx = PluginContext::new();
+        assert!(!ctx.has_notifications());
+
+        ctx.add_notification("Hello".to_string());
+        assert!(ctx.has_notifications());
+
+        ctx.add_notification("World".to_string());
+
+        let notes = ctx.take_notifications();
+        assert_eq!(notes.len(), 2);
+        assert_eq!(notes[0], "Hello");
+        assert_eq!(notes[1], "World");
+
+        // After take, should be empty
+        assert!(!ctx.has_notifications());
+        assert!(ctx.take_notifications().is_empty());
+    }
+}

--- a/src/plugin/lua.rs
+++ b/src/plugin/lua.rs
@@ -1,0 +1,423 @@
+//! Lua runtime management for plugin system
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use mlua::Lua;
+
+use super::api::PluginContext;
+
+/// Plugin system error
+#[derive(Debug)]
+pub enum PluginError {
+    /// Failed to create Lua runtime
+    RuntimeError(String),
+    /// Failed to load plugin file
+    LoadError(String),
+    /// Plugin execution error
+    ExecutionError(String),
+}
+
+impl std::fmt::Display for PluginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PluginError::RuntimeError(msg) => write!(f, "Plugin runtime error: {}", msg),
+            PluginError::LoadError(msg) => write!(f, "Plugin load error: {}", msg),
+            PluginError::ExecutionError(msg) => write!(f, "Plugin execution error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for PluginError {}
+
+impl From<mlua::Error> for PluginError {
+    fn from(err: mlua::Error) -> Self {
+        PluginError::ExecutionError(err.to_string())
+    }
+}
+
+/// Manages the Lua plugin runtime
+pub struct PluginManager {
+    /// Lua runtime instance
+    lua: Lua,
+    /// Shared plugin context
+    context: Arc<Mutex<PluginContext>>,
+    /// Whether plugins are loaded
+    loaded: bool,
+    /// Notifications to display (queued from plugins)
+    pending_notifications: Vec<String>,
+}
+
+impl PluginManager {
+    /// Create a new plugin manager
+    pub fn new() -> Result<Self, PluginError> {
+        let lua = Lua::new();
+        let context = Arc::new(Mutex::new(PluginContext::new()));
+
+        // Set up the 'fv' global table with API functions
+        Self::setup_api(&lua, Arc::clone(&context))?;
+
+        Ok(Self {
+            lua,
+            context,
+            loaded: false,
+            pending_notifications: Vec::new(),
+        })
+    }
+
+    /// Set up the 'fv' API table in Lua
+    fn setup_api(lua: &Lua, context: Arc<Mutex<PluginContext>>) -> Result<(), PluginError> {
+        let globals = lua.globals();
+
+        // Create 'fv' table
+        let fv = lua.create_table().map_err(PluginError::from)?;
+
+        // fv.current_file() -> string or nil
+        {
+            let ctx = Arc::clone(&context);
+            let current_file = lua
+                .create_function(move |_, ()| {
+                    let ctx = ctx.lock().unwrap();
+                    Ok(ctx.current_file().map(|p| p.to_string_lossy().to_string()))
+                })
+                .map_err(PluginError::from)?;
+            fv.set("current_file", current_file)
+                .map_err(PluginError::from)?;
+        }
+
+        // fv.current_dir() -> string
+        {
+            let ctx = Arc::clone(&context);
+            let current_dir = lua
+                .create_function(move |_, ()| {
+                    let ctx = ctx.lock().unwrap();
+                    Ok(ctx.current_dir().to_string_lossy().to_string())
+                })
+                .map_err(PluginError::from)?;
+            fv.set("current_dir", current_dir)
+                .map_err(PluginError::from)?;
+        }
+
+        // fv.selected_files() -> table (array of strings)
+        {
+            let ctx = Arc::clone(&context);
+            let selected_files = lua
+                .create_function(move |lua, ()| {
+                    let ctx = ctx.lock().unwrap();
+                    let files = ctx.selected_files();
+                    let table = lua.create_table()?;
+                    for (i, path) in files.iter().enumerate() {
+                        table.set(i + 1, path.to_string_lossy().to_string())?;
+                    }
+                    Ok(table)
+                })
+                .map_err(PluginError::from)?;
+            fv.set("selected_files", selected_files)
+                .map_err(PluginError::from)?;
+        }
+
+        // fv.notify(message) -> nil
+        {
+            let ctx = Arc::clone(&context);
+            let notify = lua
+                .create_function(move |_, msg: String| {
+                    let mut ctx = ctx.lock().unwrap();
+                    ctx.add_notification(msg);
+                    Ok(())
+                })
+                .map_err(PluginError::from)?;
+            fv.set("notify", notify).map_err(PluginError::from)?;
+        }
+
+        // fv.version() -> string
+        {
+            let version = lua
+                .create_function(|_, ()| Ok(env!("CARGO_PKG_VERSION").to_string()))
+                .map_err(PluginError::from)?;
+            fv.set("version", version).map_err(PluginError::from)?;
+        }
+
+        // fv.is_dir(path) -> boolean
+        {
+            let is_dir = lua
+                .create_function(|_, path: String| Ok(Path::new(&path).is_dir()))
+                .map_err(PluginError::from)?;
+            fv.set("is_dir", is_dir).map_err(PluginError::from)?;
+        }
+
+        // fv.file_exists(path) -> boolean
+        {
+            let file_exists = lua
+                .create_function(|_, path: String| Ok(Path::new(&path).exists()))
+                .map_err(PluginError::from)?;
+            fv.set("file_exists", file_exists)
+                .map_err(PluginError::from)?;
+        }
+
+        // Set the fv table as a global
+        globals.set("fv", fv).map_err(PluginError::from)?;
+
+        Ok(())
+    }
+
+    /// Get the plugin directory path
+    pub fn plugin_dir() -> Option<PathBuf> {
+        dirs::config_dir().map(|p| p.join("fileview").join("plugins"))
+    }
+
+    /// Get the init.lua path
+    pub fn init_lua_path() -> Option<PathBuf> {
+        Self::plugin_dir().map(|p| p.join("init.lua"))
+    }
+
+    /// Load plugins from the plugin directory
+    pub fn load_plugins(&mut self) -> Result<(), PluginError> {
+        if self.loaded {
+            return Ok(());
+        }
+
+        let init_path = match Self::init_lua_path() {
+            Some(p) if p.exists() => p,
+            _ => {
+                // No init.lua found, that's fine
+                self.loaded = true;
+                return Ok(());
+            }
+        };
+
+        // Read and execute init.lua
+        let code = std::fs::read_to_string(&init_path).map_err(|e| {
+            PluginError::LoadError(format!("Failed to read {}: {}", init_path.display(), e))
+        })?;
+
+        self.lua
+            .load(&code)
+            .set_name(init_path.to_string_lossy())
+            .exec()
+            .map_err(|e| {
+                PluginError::ExecutionError(format!("Error in {}: {}", init_path.display(), e))
+            })?;
+
+        // Collect notifications
+        self.collect_notifications();
+
+        self.loaded = true;
+        Ok(())
+    }
+
+    /// Update the plugin context with current state
+    pub fn update_context(
+        &mut self,
+        current_file: Option<PathBuf>,
+        current_dir: PathBuf,
+        selected_files: Vec<PathBuf>,
+    ) {
+        let mut ctx = self.context.lock().unwrap();
+        ctx.set_current_file(current_file);
+        ctx.set_current_dir(current_dir);
+        ctx.set_selected_files(selected_files);
+    }
+
+    /// Collect pending notifications from the context
+    fn collect_notifications(&mut self) {
+        let mut ctx = self.context.lock().unwrap();
+        self.pending_notifications
+            .extend(ctx.take_notifications());
+    }
+
+    /// Take pending notifications
+    pub fn take_notifications(&mut self) -> Vec<String> {
+        self.collect_notifications();
+        std::mem::take(&mut self.pending_notifications)
+    }
+
+    /// Execute a Lua string (for testing or REPL)
+    pub fn exec(&mut self, code: &str) -> Result<(), PluginError> {
+        self.lua.load(code).exec().map_err(PluginError::from)?;
+        self.collect_notifications();
+        Ok(())
+    }
+
+    /// Evaluate a Lua expression and return the result as a string
+    pub fn eval(&self, code: &str) -> Result<String, PluginError> {
+        let result: mlua::Value = self.lua.load(code).eval().map_err(PluginError::from)?;
+        Ok(format_lua_value(&result))
+    }
+}
+
+impl Default for PluginManager {
+    fn default() -> Self {
+        Self::new().expect("Failed to create plugin manager")
+    }
+}
+
+/// Format a Lua value as a string for display
+fn format_lua_value(value: &mlua::Value) -> String {
+    match value {
+        mlua::Value::Nil => "nil".to_string(),
+        mlua::Value::Boolean(b) => b.to_string(),
+        mlua::Value::Integer(i) => i.to_string(),
+        mlua::Value::Number(n) => n.to_string(),
+        mlua::Value::String(s) => s
+            .to_str()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|_| "<invalid utf8>".to_string()),
+        mlua::Value::Table(_) => "<table>".to_string(),
+        mlua::Value::Function(_) => "<function>".to_string(),
+        mlua::Value::Thread(_) => "<thread>".to_string(),
+        mlua::Value::LightUserData(_) => "<userdata>".to_string(),
+        mlua::Value::UserData(_) => "<userdata>".to_string(),
+        mlua::Value::Error(e) => format!("<error: {}>", e),
+        _ => "<unknown>".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plugin_manager_new() {
+        let manager = PluginManager::new();
+        assert!(manager.is_ok());
+    }
+
+    #[test]
+    fn test_fv_version() {
+        let manager = PluginManager::new().unwrap();
+        let result = manager.eval("fv.version()");
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("1.")); // Should contain version like "1.19.0"
+    }
+
+    #[test]
+    fn test_fv_current_dir() {
+        let mut manager = PluginManager::new().unwrap();
+        manager.update_context(None, PathBuf::from("/test/dir"), vec![]);
+
+        let result = manager.eval("fv.current_dir()");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "/test/dir");
+    }
+
+    #[test]
+    fn test_fv_current_file() {
+        let mut manager = PluginManager::new().unwrap();
+        manager.update_context(
+            Some(PathBuf::from("/test/file.txt")),
+            PathBuf::from("/test"),
+            vec![],
+        );
+
+        let result = manager.eval("fv.current_file()");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "/test/file.txt");
+    }
+
+    #[test]
+    fn test_fv_current_file_nil() {
+        let mut manager = PluginManager::new().unwrap();
+        manager.update_context(None, PathBuf::from("/test"), vec![]);
+
+        let result = manager.eval("fv.current_file()");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "nil");
+    }
+
+    #[test]
+    fn test_fv_selected_files() {
+        let mut manager = PluginManager::new().unwrap();
+        manager.update_context(
+            None,
+            PathBuf::from("/test"),
+            vec![PathBuf::from("/test/a.txt"), PathBuf::from("/test/b.txt")],
+        );
+
+        let result = manager.eval("#fv.selected_files()");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "2");
+    }
+
+    #[test]
+    fn test_fv_notify() {
+        let mut manager = PluginManager::new().unwrap();
+        manager.exec("fv.notify('Hello from Lua!')").unwrap();
+
+        let notifications = manager.take_notifications();
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(notifications[0], "Hello from Lua!");
+    }
+
+    #[test]
+    fn test_fv_is_dir() {
+        let manager = PluginManager::new().unwrap();
+
+        // Test with a directory that definitely exists
+        let result = manager.eval("fv.is_dir('/')");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "true");
+
+        // Test with a file that doesn't exist
+        let result = manager.eval("fv.is_dir('/nonexistent/path')");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "false");
+    }
+
+    #[test]
+    fn test_fv_file_exists() {
+        let manager = PluginManager::new().unwrap();
+
+        // Test with root directory
+        let result = manager.eval("fv.file_exists('/')");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "true");
+
+        // Test with nonexistent path
+        let result = manager.eval("fv.file_exists('/definitely/does/not/exist/xyz123')");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "false");
+    }
+
+    #[test]
+    fn test_exec_lua_code() {
+        let mut manager = PluginManager::new().unwrap();
+        let result = manager.exec("local x = 1 + 1");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_exec_lua_error() {
+        let mut manager = PluginManager::new().unwrap();
+        let result = manager.exec("this is not valid lua");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_plugin_dir() {
+        let dir = PluginManager::plugin_dir();
+        assert!(dir.is_some());
+        let dir = dir.unwrap();
+        assert!(dir.to_string_lossy().contains("fileview"));
+        assert!(dir.to_string_lossy().contains("plugins"));
+    }
+
+    #[test]
+    fn test_multiple_notifications() {
+        let mut manager = PluginManager::new().unwrap();
+        manager
+            .exec(
+                r#"
+            fv.notify("First")
+            fv.notify("Second")
+            fv.notify("Third")
+        "#,
+            )
+            .unwrap();
+
+        let notifications = manager.take_notifications();
+        assert_eq!(notifications.len(), 3);
+        assert_eq!(notifications[0], "First");
+        assert_eq!(notifications[1], "Second");
+        assert_eq!(notifications[2], "Third");
+    }
+}

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,0 +1,28 @@
+//! Plugin system for FileView
+//!
+//! This module provides Lua scripting support for extending FileView.
+//! Plugins can access file information, execute actions, and register
+//! custom commands.
+//!
+//! # Plugin Location
+//!
+//! Plugins are loaded from `~/.config/fileview/plugins/init.lua`
+//!
+//! # Example Plugin
+//!
+//! ```lua
+//! -- ~/.config/fileview/plugins/init.lua
+//! fv.notify("FileView plugin loaded!")
+//!
+//! -- Access current file
+//! local file = fv.current_file()
+//! if file then
+//!     print("Current file: " .. file)
+//! end
+//! ```
+
+mod api;
+mod lua;
+
+pub use api::PluginContext;
+pub use lua::{PluginError, PluginManager};


### PR DESCRIPTION
## Summary

- **Lua plugin system**: First phase of plugin support using Lua 5.4
- Plugin location: `~/.config/fileview/plugins/init.lua`
- Read-only API for accessing FileView state

## New Features

### Lua API

```lua
-- Access current state
fv.current_file()      -- Get focused file path
fv.current_dir()       -- Get current directory
fv.selected_files()    -- Get selected files list

-- Utility functions
fv.notify(msg)         -- Display notification
fv.version()           -- Get FileView version
fv.is_dir(path)        -- Check if path is directory
fv.file_exists(path)   -- Check if path exists
```

## New Files

- `src/plugin/mod.rs`: Plugin system module entry
- `src/plugin/lua.rs`: Lua runtime management (~280 lines)
- `src/plugin/api.rs`: Plugin context for state sharing (~100 lines)

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (436 tests total, 18 new plugin tests)