### PR TITLE
release: v1.20.0 - Lua plugin action API (Phase 12b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-02-03
+
+### Added
+
+- **Lua plugin action API (Phase 12b)**: Plugins can now trigger FileView actions
+  - `fv.navigate(path)`: Navigate to a directory
+  - `fv.select(path)`: Add a file to selection
+  - `fv.deselect(path)`: Remove a file from selection
+  - `fv.clear_selection()`: Clear all selections
+  - `fv.refresh()`: Refresh the tree view
+  - `fv.set_clipboard(text)`: Set clipboard text
+  - `fv.focus(path)`: Focus on a specific file (reveal and select)
+  - Actions are queued and processed by the event loop
+
+### Changed
+
+- `PluginContext` now includes action queue for plugin-triggered actions
+- `PluginManager` collects actions alongside notifications
+
+### Tests
+
+- Added 15 new unit tests for action API (12 lua + 3 api)
+- Total plugin tests: 30
+
 ## [1.19.0] - 2026-02-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.19.0"
+version = "1.20.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -24,5 +24,5 @@
 mod api;
 mod lua;
 
-pub use api::PluginContext;
+pub use api::{PluginAction, PluginContext};
 pub use lua::{PluginError, PluginManager};


### PR DESCRIPTION
## Summary

- **Lua plugin action API**: Plugins can now trigger FileView actions
- Builds on v1.19.0's read-only API with write capabilities

## New API Functions

```lua
-- Navigation
fv.navigate("/path/to/dir")     -- Navigate to directory

-- Selection
fv.select("/path/to/file")      -- Add to selection
fv.deselect("/path/to/file")    -- Remove from selection
fv.clear_selection()            -- Clear all selections

-- Actions
fv.refresh()                    -- Refresh tree view
fv.set_clipboard("text")        -- Set clipboard
fv.focus("/path/to/file")       -- Focus on file
```

## Example Plugin

```lua
-- Select all .rs files and copy paths
for _, file in ipairs(fv.selected_files()) do
    if file:match("%.rs$") then
        fv.select(file)
    end
end
fv.notify("Selected " .. #fv.selected_files() .. " Rust files")
```

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (30 plugin tests)