### PR TITLE
release: v1.21.0 - Lua plugin registration API (Phase 12c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.0] - 2026-02-03
+
+### Added
+
+- **Lua plugin registration API (Phase 12c)**: Register custom commands, event handlers, and previewers
+  - `fv.register_command(name, fn)`: Register a custom command callable from FileView
+  - `fv.on(event, fn)`: Register event handlers for FileView events
+    - Supported events: `file_selected`, `directory_changed`, `selection_changed`, `start`, `before_quit`
+    - Multiple handlers can be registered for the same event
+  - `fv.register_previewer(pattern, fn)`: Register custom file previewers by glob pattern
+    - Pattern supports `*` (any characters) and `?` (single character)
+    - Returns preview content as string
+  - Internal storage tables: `fv._commands`, `fv._events`, `fv._previewers`
+
+### New Methods (PluginManager)
+
+- `has_command(name)`: Check if command is registered
+- `list_commands()`: List all registered command names
+- `invoke_command(name)`: Execute a registered command
+- `fire_event(event, arg)`: Fire event and call all handlers
+- `has_previewer(pattern)`: Check if previewer is registered
+- `list_previewers()`: List all registered previewer patterns
+- `find_previewer(filename)`: Find matching previewer for filename
+- `invoke_previewer(pattern, path)`: Execute previewer and get result
+
+### Tests
+
+- Added 20 new unit tests for registration API
+- Total plugin tests: 50
+
 ## [1.20.0] - 2026-02-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.20.0"
+version = "1.21.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -5,6 +5,46 @@
 
 use std::path::PathBuf;
 
+/// Plugin events that can be listened to
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PluginEvent {
+    /// Triggered when a file is focused/selected
+    FileSelected,
+    /// Triggered when navigating to a new directory
+    DirectoryChanged,
+    /// Triggered when the selection set changes
+    SelectionChanged,
+    /// Triggered on application start (after plugins load)
+    Start,
+    /// Triggered before quitting
+    BeforeQuit,
+}
+
+impl PluginEvent {
+    /// Get the event name as used in Lua
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PluginEvent::FileSelected => "file_selected",
+            PluginEvent::DirectoryChanged => "directory_changed",
+            PluginEvent::SelectionChanged => "selection_changed",
+            PluginEvent::Start => "start",
+            PluginEvent::BeforeQuit => "before_quit",
+        }
+    }
+
+    /// Parse event name from string
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "file_selected" => Some(PluginEvent::FileSelected),
+            "directory_changed" => Some(PluginEvent::DirectoryChanged),
+            "selection_changed" => Some(PluginEvent::SelectionChanged),
+            "start" => Some(PluginEvent::Start),
+            "before_quit" => Some(PluginEvent::BeforeQuit),
+            _ => None,
+        }
+    }
+}
+
 /// Actions that can be triggered from plugins
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PluginAction {
@@ -221,5 +261,39 @@ mod tests {
             actions[0],
             PluginAction::Focus(PathBuf::from("/test/file.txt"))
         );
+    }
+
+    // === PluginEvent tests ===
+
+    #[test]
+    fn test_plugin_event_as_str() {
+        assert_eq!(PluginEvent::FileSelected.as_str(), "file_selected");
+        assert_eq!(PluginEvent::DirectoryChanged.as_str(), "directory_changed");
+        assert_eq!(PluginEvent::SelectionChanged.as_str(), "selection_changed");
+        assert_eq!(PluginEvent::Start.as_str(), "start");
+        assert_eq!(PluginEvent::BeforeQuit.as_str(), "before_quit");
+    }
+
+    #[test]
+    fn test_plugin_event_parse() {
+        assert_eq!(
+            PluginEvent::parse("file_selected"),
+            Some(PluginEvent::FileSelected)
+        );
+        assert_eq!(
+            PluginEvent::parse("directory_changed"),
+            Some(PluginEvent::DirectoryChanged)
+        );
+        assert_eq!(
+            PluginEvent::parse("selection_changed"),
+            Some(PluginEvent::SelectionChanged)
+        );
+        assert_eq!(PluginEvent::parse("start"), Some(PluginEvent::Start));
+        assert_eq!(
+            PluginEvent::parse("before_quit"),
+            Some(PluginEvent::BeforeQuit)
+        );
+        assert_eq!(PluginEvent::parse("invalid"), None);
+        assert_eq!(PluginEvent::parse(""), None);
     }
 }

--- a/src/plugin/lua.rs
+++ b/src/plugin/lua.rs
@@ -3,9 +3,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use mlua::Lua;
+use mlua::{Function, Lua};
 
-use super::api::{PluginAction, PluginContext};
+use super::api::{PluginAction, PluginContext, PluginEvent};
 
 /// Plugin system error
 #[derive(Debug)]
@@ -259,6 +259,80 @@ impl PluginManager {
             fv.set("focus", focus).map_err(PluginError::from)?;
         }
 
+        // === Registration API (Phase 12c) ===
+
+        // Internal storage tables
+        let commands_table = lua.create_table().map_err(PluginError::from)?;
+        let events_table = lua.create_table().map_err(PluginError::from)?;
+        let previewers_table = lua.create_table().map_err(PluginError::from)?;
+
+        fv.set("_commands", commands_table)
+            .map_err(PluginError::from)?;
+        fv.set("_events", events_table).map_err(PluginError::from)?;
+        fv.set("_previewers", previewers_table)
+            .map_err(PluginError::from)?;
+
+        // fv.register_command(name, fn) -> nil
+        // Register a custom command
+        {
+            let register_command = lua
+                .create_function(|lua, (name, func): (String, Function)| {
+                    let globals = lua.globals();
+                    let fv: mlua::Table = globals.get("fv")?;
+                    let commands: mlua::Table = fv.get("_commands")?;
+                    commands.set(name, func)?;
+                    Ok(())
+                })
+                .map_err(PluginError::from)?;
+            fv.set("register_command", register_command)
+                .map_err(PluginError::from)?;
+        }
+
+        // fv.on(event, fn) -> nil
+        // Register an event handler
+        {
+            let on = lua
+                .create_function(|lua, (event, func): (String, Function)| {
+                    let globals = lua.globals();
+                    let fv: mlua::Table = globals.get("fv")?;
+                    let events: mlua::Table = fv.get("_events")?;
+
+                    // Get or create the handler list for this event
+                    let handlers: mlua::Table = match events.get::<mlua::Table>(event.clone()) {
+                        Ok(t) => t,
+                        Err(_) => {
+                            let new_table = lua.create_table()?;
+                            events.set(event.clone(), new_table.clone())?;
+                            new_table
+                        }
+                    };
+
+                    // Append the handler
+                    let len = handlers.len()?;
+                    handlers.set(len + 1, func)?;
+
+                    Ok(())
+                })
+                .map_err(PluginError::from)?;
+            fv.set("on", on).map_err(PluginError::from)?;
+        }
+
+        // fv.register_previewer(pattern, fn) -> nil
+        // Register a custom previewer for a file pattern
+        {
+            let register_previewer = lua
+                .create_function(|lua, (pattern, func): (String, Function)| {
+                    let globals = lua.globals();
+                    let fv: mlua::Table = globals.get("fv")?;
+                    let previewers: mlua::Table = fv.get("_previewers")?;
+                    previewers.set(pattern, func)?;
+                    Ok(())
+                })
+                .map_err(PluginError::from)?;
+            fv.set("register_previewer", register_previewer)
+                .map_err(PluginError::from)?;
+        }
+
         // Set the fv table as a global
         globals.set("fv", fv).map_err(PluginError::from)?;
 
@@ -359,6 +433,174 @@ impl PluginManager {
     pub fn eval(&self, code: &str) -> Result<String, PluginError> {
         let result: mlua::Value = self.lua.load(code).eval().map_err(PluginError::from)?;
         Ok(format_lua_value(&result))
+    }
+
+    // === Phase 12c: Registration API methods ===
+
+    /// Check if a command is registered
+    pub fn has_command(&self, name: &str) -> bool {
+        let Ok(globals) = self.lua.globals().get::<mlua::Table>("fv") else {
+            return false;
+        };
+        let Ok(commands) = globals.get::<mlua::Table>("_commands") else {
+            return false;
+        };
+        commands.contains_key(name).unwrap_or(false)
+    }
+
+    /// Get list of registered command names
+    pub fn list_commands(&self) -> Vec<String> {
+        let mut names = Vec::new();
+        let Ok(globals) = self.lua.globals().get::<mlua::Table>("fv") else {
+            return names;
+        };
+        let Ok(commands) = globals.get::<mlua::Table>("_commands") else {
+            return names;
+        };
+        for (name, _) in commands.pairs::<String, mlua::Value>().flatten() {
+            names.push(name);
+        }
+        names
+    }
+
+    /// Invoke a registered command by name
+    pub fn invoke_command(&mut self, name: &str) -> Result<(), PluginError> {
+        let globals = self.lua.globals();
+        let fv: mlua::Table = globals.get("fv").map_err(PluginError::from)?;
+        let commands: mlua::Table = fv.get("_commands").map_err(PluginError::from)?;
+
+        let func: Function = commands
+            .get(name)
+            .map_err(|_| PluginError::ExecutionError(format!("Command '{}' not found", name)))?;
+
+        func.call::<()>(()).map_err(|e| {
+            PluginError::ExecutionError(format!("Error in command '{}': {}", name, e))
+        })?;
+
+        self.collect_notifications();
+        self.collect_actions();
+        Ok(())
+    }
+
+    /// Fire an event and call all registered handlers
+    pub fn fire_event(&mut self, event: PluginEvent, arg: Option<&str>) -> Result<(), PluginError> {
+        let globals = self.lua.globals();
+        let fv: mlua::Table = globals.get("fv").map_err(PluginError::from)?;
+        let events: mlua::Table = fv.get("_events").map_err(PluginError::from)?;
+
+        let event_name = event.as_str();
+        let handlers: mlua::Table = match events.get(event_name) {
+            Ok(t) => t,
+            Err(_) => return Ok(()), // No handlers registered
+        };
+
+        // Call each handler
+        for (_, func) in handlers.pairs::<i64, Function>().flatten() {
+            if let Some(arg_str) = arg {
+                let _ = func.call::<()>(arg_str);
+            } else {
+                let _ = func.call::<()>(());
+            }
+        }
+
+        self.collect_notifications();
+        self.collect_actions();
+        Ok(())
+    }
+
+    /// Check if a previewer is registered for a pattern
+    pub fn has_previewer(&self, pattern: &str) -> bool {
+        let Ok(globals) = self.lua.globals().get::<mlua::Table>("fv") else {
+            return false;
+        };
+        let Ok(previewers) = globals.get::<mlua::Table>("_previewers") else {
+            return false;
+        };
+        previewers.contains_key(pattern).unwrap_or(false)
+    }
+
+    /// Get list of registered previewer patterns
+    pub fn list_previewers(&self) -> Vec<String> {
+        let mut patterns = Vec::new();
+        let Ok(globals) = self.lua.globals().get::<mlua::Table>("fv") else {
+            return patterns;
+        };
+        let Ok(previewers) = globals.get::<mlua::Table>("_previewers") else {
+            return patterns;
+        };
+        for (pattern, _) in previewers.pairs::<String, mlua::Value>().flatten() {
+            patterns.push(pattern);
+        }
+        patterns
+    }
+
+    /// Find a previewer that matches the given filename
+    /// Returns the pattern that matched
+    pub fn find_previewer(&self, filename: &str) -> Option<String> {
+        self.list_previewers()
+            .into_iter()
+            .find(|pattern| matches_glob(pattern, filename))
+    }
+
+    /// Invoke a previewer and get the result
+    /// Returns the preview content as a string
+    pub fn invoke_previewer(&mut self, pattern: &str, path: &str) -> Result<String, PluginError> {
+        let globals = self.lua.globals();
+        let fv: mlua::Table = globals.get("fv").map_err(PluginError::from)?;
+        let previewers: mlua::Table = fv.get("_previewers").map_err(PluginError::from)?;
+
+        let func: Function = previewers.get(pattern).map_err(|_| {
+            PluginError::ExecutionError(format!("Previewer '{}' not found", pattern))
+        })?;
+
+        let result: String = func.call(path).map_err(|e| {
+            PluginError::ExecutionError(format!("Error in previewer '{}': {}", pattern, e))
+        })?;
+
+        self.collect_notifications();
+        self.collect_actions();
+        Ok(result)
+    }
+}
+
+/// Simple glob pattern matching (supports * and ?)
+fn matches_glob(pattern: &str, text: &str) -> bool {
+    let pattern_chars: Vec<char> = pattern.chars().collect();
+    let text_chars: Vec<char> = text.chars().collect();
+    matches_glob_recursive(&pattern_chars, &text_chars, 0, 0)
+}
+
+fn matches_glob_recursive(pattern: &[char], text: &[char], pi: usize, ti: usize) -> bool {
+    if pi == pattern.len() {
+        return ti == text.len();
+    }
+
+    match pattern[pi] {
+        '*' => {
+            // Match zero or more characters
+            for i in ti..=text.len() {
+                if matches_glob_recursive(pattern, text, pi + 1, i) {
+                    return true;
+                }
+            }
+            false
+        }
+        '?' => {
+            // Match exactly one character
+            if ti < text.len() {
+                matches_glob_recursive(pattern, text, pi + 1, ti + 1)
+            } else {
+                false
+            }
+        }
+        c => {
+            // Match exact character
+            if ti < text.len() && text[ti] == c {
+                matches_glob_recursive(pattern, text, pi + 1, ti + 1)
+            } else {
+                false
+            }
+        }
     }
 }
 
@@ -675,5 +917,265 @@ mod tests {
 
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0], PluginAction::Navigate(PathBuf::from("/test")));
+    }
+
+    // === Phase 12c: Registration API Tests ===
+
+    #[test]
+    fn test_register_command() {
+        let mut manager = PluginManager::new().unwrap();
+
+        // Register a command
+        manager
+            .exec(
+                r#"
+            fv.register_command("test-cmd", function()
+                fv.notify("Command executed!")
+            end)
+        "#,
+            )
+            .unwrap();
+
+        // Check it's registered
+        assert!(manager.has_command("test-cmd"));
+        assert!(!manager.has_command("nonexistent"));
+    }
+
+    #[test]
+    fn test_invoke_command() {
+        let mut manager = PluginManager::new().unwrap();
+
+        // Register a command that sets a notification
+        manager
+            .exec(
+                r#"
+            fv.register_command("hello", function()
+                fv.notify("Hello from command!")
+            end)
+        "#,
+            )
+            .unwrap();
+
+        // Invoke it
+        manager.invoke_command("hello").unwrap();
+
+        let notifications = manager.take_notifications();
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(notifications[0], "Hello from command!");
+    }
+
+    #[test]
+    fn test_invoke_command_not_found() {
+        let mut manager = PluginManager::new().unwrap();
+
+        let result = manager.invoke_command("nonexistent");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_list_commands() {
+        let mut manager = PluginManager::new().unwrap();
+
+        manager
+            .exec(
+                r#"
+            fv.register_command("cmd-a", function() end)
+            fv.register_command("cmd-b", function() end)
+        "#,
+            )
+            .unwrap();
+
+        let commands = manager.list_commands();
+        assert_eq!(commands.len(), 2);
+        assert!(commands.contains(&"cmd-a".to_string()));
+        assert!(commands.contains(&"cmd-b".to_string()));
+    }
+
+    #[test]
+    fn test_on_event() {
+        let mut manager = PluginManager::new().unwrap();
+
+        // Register an event handler
+        manager
+            .exec(
+                r#"
+            fv.on("file_selected", function(path)
+                fv.notify("Selected: " .. (path or "nil"))
+            end)
+        "#,
+            )
+            .unwrap();
+
+        // Fire the event
+        manager
+            .fire_event(PluginEvent::FileSelected, Some("/test/file.txt"))
+            .unwrap();
+
+        let notifications = manager.take_notifications();
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(notifications[0], "Selected: /test/file.txt");
+    }
+
+    #[test]
+    fn test_multiple_event_handlers() {
+        let mut manager = PluginManager::new().unwrap();
+
+        // Register multiple handlers for the same event
+        manager
+            .exec(
+                r#"
+            fv.on("start", function()
+                fv.notify("Handler 1")
+            end)
+            fv.on("start", function()
+                fv.notify("Handler 2")
+            end)
+        "#,
+            )
+            .unwrap();
+
+        // Fire the event
+        manager.fire_event(PluginEvent::Start, None).unwrap();
+
+        let notifications = manager.take_notifications();
+        assert_eq!(notifications.len(), 2);
+        assert_eq!(notifications[0], "Handler 1");
+        assert_eq!(notifications[1], "Handler 2");
+    }
+
+    #[test]
+    fn test_fire_event_no_handlers() {
+        let mut manager = PluginManager::new().unwrap();
+
+        // Should not error when no handlers registered
+        let result = manager.fire_event(PluginEvent::BeforeQuit, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_register_previewer() {
+        let mut manager = PluginManager::new().unwrap();
+
+        manager
+            .exec(
+                r#"
+            fv.register_previewer("*.csv", function(path)
+                return "CSV preview for: " .. path
+            end)
+        "#,
+            )
+            .unwrap();
+
+        assert!(manager.has_previewer("*.csv"));
+        assert!(!manager.has_previewer("*.json"));
+    }
+
+    #[test]
+    fn test_invoke_previewer() {
+        let mut manager = PluginManager::new().unwrap();
+
+        manager
+            .exec(
+                r#"
+            fv.register_previewer("*.md", function(path)
+                return "Markdown: " .. path
+            end)
+        "#,
+            )
+            .unwrap();
+
+        let result = manager.invoke_previewer("*.md", "/test/README.md");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Markdown: /test/README.md");
+    }
+
+    #[test]
+    fn test_find_previewer() {
+        let mut manager = PluginManager::new().unwrap();
+
+        manager
+            .exec(
+                r#"
+            fv.register_previewer("*.rs", function(path) return "Rust" end)
+            fv.register_previewer("*.py", function(path) return "Python" end)
+        "#,
+            )
+            .unwrap();
+
+        assert_eq!(manager.find_previewer("main.rs"), Some("*.rs".to_string()));
+        assert_eq!(
+            manager.find_previewer("script.py"),
+            Some("*.py".to_string())
+        );
+        assert_eq!(manager.find_previewer("file.txt"), None);
+    }
+
+    #[test]
+    fn test_list_previewers() {
+        let mut manager = PluginManager::new().unwrap();
+
+        manager
+            .exec(
+                r#"
+            fv.register_previewer("*.json", function(path) return "{}" end)
+            fv.register_previewer("*.yaml", function(path) return "---" end)
+        "#,
+            )
+            .unwrap();
+
+        let previewers = manager.list_previewers();
+        assert_eq!(previewers.len(), 2);
+        assert!(previewers.contains(&"*.json".to_string()));
+        assert!(previewers.contains(&"*.yaml".to_string()));
+    }
+
+    // === Glob matching tests ===
+
+    #[test]
+    fn test_matches_glob_exact() {
+        assert!(matches_glob("test.txt", "test.txt"));
+        assert!(!matches_glob("test.txt", "test.rs"));
+    }
+
+    #[test]
+    fn test_matches_glob_star() {
+        assert!(matches_glob("*.txt", "file.txt"));
+        assert!(matches_glob("*.txt", "another.txt"));
+        assert!(!matches_glob("*.txt", "file.rs"));
+        assert!(matches_glob("test*", "test.txt"));
+        assert!(matches_glob("test*", "testing"));
+        assert!(matches_glob("*test*", "my_test_file"));
+    }
+
+    #[test]
+    fn test_matches_glob_question() {
+        assert!(matches_glob("file?.txt", "file1.txt"));
+        assert!(matches_glob("file?.txt", "fileA.txt"));
+        assert!(!matches_glob("file?.txt", "file12.txt"));
+    }
+
+    #[test]
+    fn test_matches_glob_combined() {
+        assert!(matches_glob("*.??", "file.rs"));
+        assert!(matches_glob("*.??", "test.py"));
+        assert!(!matches_glob("*.??", "file.txt"));
+    }
+
+    // === PluginEvent tests ===
+
+    #[test]
+    fn test_plugin_event_as_str() {
+        assert_eq!(PluginEvent::FileSelected.as_str(), "file_selected");
+        assert_eq!(PluginEvent::DirectoryChanged.as_str(), "directory_changed");
+        assert_eq!(PluginEvent::Start.as_str(), "start");
+    }
+
+    #[test]
+    fn test_plugin_event_parse() {
+        assert_eq!(
+            PluginEvent::parse("file_selected"),
+            Some(PluginEvent::FileSelected)
+        );
+        assert_eq!(PluginEvent::parse("invalid"), None);
     }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -24,5 +24,5 @@
 mod api;
 mod lua;
 
-pub use api::{PluginAction, PluginContext};
+pub use api::{PluginAction, PluginContext, PluginEvent};
 pub use lua::{PluginError, PluginManager};


### PR DESCRIPTION
## Summary

- Add `fv.register_command(name, fn)` for registering custom commands
- Add `fv.on(event, fn)` for event handlers (file_selected, directory_changed, selection_changed, start, before_quit)
- Add `fv.register_previewer(pattern, fn)` for custom file previewers with glob pattern matching
- Add PluginManager methods for invoking commands, firing events, and finding previewers
- Add 20 new unit tests for registration API

## Test plan

- [x] `cargo check` passed
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` passed (346 tests)