### PR TITLE
release: v1.23.0 - Adaptive status bar for narrow terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0] - 2026-02-03
+
+### Added
+
+- **Adaptive status bar for narrow terminals**: Status bar now adjusts layout based on screen width
+  - Wide screens (≥100 chars): Full 50:50 split with all information
+  - Medium screens (60-99 chars): Abbreviated display with 45:55 split
+  - Narrow screens (<60 chars): Single panel with essential info only
+  - Abbreviated labels: "Selected: 3" → "Sel:3", "Copied: 2" → "Cp:2"
+  - Shortened time format: "2h ago" → "2h"
+  - Compact help text: "? for help" → "?" on narrow screens
+
 ## [1.22.0] - 2026-02-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.20.0"
+version = "1.23.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.22.0"
+version = "1.23.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -40,6 +40,15 @@ impl SortMode {
             SortMode::Date => "date",
         }
     }
+
+    /// Get short name for narrow displays
+    pub fn short_name(&self) -> &'static str {
+        match self {
+            SortMode::Name => "N",
+            SortMode::Size => "S",
+            SortMode::Date => "D",
+        }
+    }
 }
 
 /// Main application state


### PR DESCRIPTION
## Summary

- Add responsive status bar layout that adjusts based on screen width
- Wide screens (≥100 chars): Full 50:50 split with all information
- Medium screens (60-99 chars): Abbreviated display with 45:55 split
- Narrow screens (<60 chars): Single panel with essential info only
- Abbreviated labels: "Selected: 3" → "Sel:3", "Copied: 2" → "Cp:2"
- Shortened time format: "2h ago" → "2h"

## Test plan

- [x] `cargo check` passed
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` passed (346 tests)