### PR TITLE
release: v1.24.0 - Claude Code integration features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.0] - 2026-02-03
+
+### Added
+
+- **Claude Code integration features**: Comprehensive AI pair programming support
+  - **CLI output mode** (`--tree`, `-t`): Output directory tree to stdout (non-interactive)
+    - `--depth N`: Limit tree traversal depth
+    - `--with-content`: Include file contents in pick output (Claude-friendly format)
+  - **Clipboard enhancements**:
+    - `Y`: Copy file content to system clipboard
+    - `Ctrl+Y`: Copy in Claude-friendly markdown format with syntax highlighting hints
+  - **Interactive select mode** (`--select-mode`): Simplified file selection
+    - Enter to select and output path to stdout immediately
+    - `--multi`: Allow multiple selection before confirmation
+  - **MCP server** (`--mcp-server`): JSON-RPC server for Claude Code integration
+    - `list_directory`: List files and directories
+    - `get_tree`: Get directory tree structure
+    - `read_file`: Read file content
+    - Protocol version: 2024-11-05
+
+### New Files
+
+- `src/integrate/tree.rs`: Tree output logic for CLI mode
+- `src/mcp/mod.rs`: MCP module entry point
+- `src/mcp/server.rs`: JSON-RPC server implementation
+- `src/mcp/handlers.rs`: MCP tool handlers
+- `src/mcp/types.rs`: MCP protocol type definitions
+
+### Dependencies
+
+- Added `serde_json = "1.0"` for MCP JSON-RPC serialization
+
+### Example Usage
+
+```bash
+# Output directory tree
+fv --tree --depth 2 ./src
+
+# Copy files with content for Claude
+fv --pick --with-content
+
+# Use as MCP server in Claude Code
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | fv --mcp-server
+
+# Quick file selection
+selected=$(fv --select-mode --multi)
+```
+
 ## [1.23.0] - 2026-02-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.23.0"
+version = "1.24.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -107,7 +107,10 @@ impl Config {
                 "--depth" => {
                     if let Some(depth_str) = args.next() {
                         tree_depth = Some(depth_str.parse().map_err(|_| {
-                            anyhow::anyhow!("--depth requires a positive integer, got '{}'", depth_str)
+                            anyhow::anyhow!(
+                                "--depth requires a positive integer, got '{}'",
+                                depth_str
+                            )
                         })?);
                     } else {
                         anyhow::bail!("--depth requires a value");

--- a/src/handler/action/display.rs
+++ b/src/handler/action/display.rs
@@ -115,7 +115,9 @@ pub fn handle(
                 state.set_message("No file selected");
             } else {
                 match copy_file_contents_claude_format(&paths) {
-                    Ok(count) => state.set_message(format!("Copied {} file(s) (Claude format)", count)),
+                    Ok(count) => {
+                        state.set_message(format!("Copied {} file(s) (Claude format)", count))
+                    }
                     Err(e) => state.set_message(format!("Failed: {}", e)),
                 }
             }
@@ -405,10 +407,7 @@ fn copy_file_contents_claude_format(paths: &[PathBuf]) -> anyhow::Result<usize> 
             }
 
             // Detect file extension for syntax highlighting
-            let ext = path
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("");
+            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
             contents.push(format!("### File: {}", path.display()));
             contents.push(format!("```{}", ext));

--- a/src/integrate/pick.rs
+++ b/src/integrate/pick.rs
@@ -146,10 +146,7 @@ pub fn output_paths_claude_format(paths: &[PathBuf]) -> io::Result<()> {
         writeln!(handle, "### File: {}", path.display())?;
 
         // Detect file extension for syntax highlighting
-        let ext = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("");
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
         writeln!(handle, "```{}", ext)?;
 

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -83,7 +83,11 @@ pub fn get_tree(root: &Path, path: Option<&str>, depth: Option<usize>) -> ToolCa
 }
 
 /// Write tree to output
-fn write_tree<W: std::io::Write>(out: &mut W, path: &Path, depth: Option<usize>) -> std::io::Result<()> {
+fn write_tree<W: std::io::Write>(
+    out: &mut W,
+    path: &Path,
+    depth: Option<usize>,
+) -> std::io::Result<()> {
     writeln!(out, "{}", path.display())?;
     crate::integrate::tree::print_tree_recursive_pub(out, path, "", depth, 0, false)
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -72,7 +72,9 @@ fn handle_initialize(id: Option<serde_json::Value>) -> JsonRpcResponse {
     let result = InitializeResult {
         protocol_version: "2024-11-05".to_string(),
         capabilities: ServerCapabilities {
-            tools: ToolsCapability { list_changed: false },
+            tools: ToolsCapability {
+                list_changed: false,
+            },
         },
         server_info: ServerInfo {
             name: "fileview".to_string(),
@@ -172,7 +174,9 @@ fn handle_tools_call(
             match path {
                 Some(p) => handlers::read_file(root, p),
                 None => ToolCallResult {
-                    content: vec![ToolContent::text("Missing required parameter: path".to_string())],
+                    content: vec![ToolContent::text(
+                        "Missing required parameter: path".to_string(),
+                    )],
                     is_error: Some(true),
                 },
             }


### PR DESCRIPTION
## Summary

- **CLI output mode**: `--tree`, `--depth`, `--with-content` for non-interactive tree output
- **Clipboard enhancements**: `Y` (content copy), `Ctrl+Y` (Claude markdown format)
- **Select mode**: `--select-mode`, `--multi` for simplified file selection
- **MCP server**: `--mcp-server` for JSON-RPC Claude Code integration

## Test plan

- [x] `cargo check` passed
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` passed (346 tests)
- [x] Manual test: `fv --tree --depth 2 ./src`
- [x] Manual test: `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | fv --mcp-server`