### PR TITLE
release/v1.25.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "1.24.1"
+version = "1.25.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "1.25.0"
+version = "1.25.1"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]


### PR DESCRIPTION
## Summary
- Improve help popup with gitstack-style responsive design
- Add responsive layout (very_compact/compact/normal based on width)
- Use color scheme: Yellow (labels), Cyan (keys), White (descriptions)
- Add dark overlay background
- Include new Ctrl+G and Ctrl+T shortcuts in help

## Changes
- `src/render/status.rs`: Refactored `render_help_popup` function