### PR TITLE
chore(release): bump version to 2.0.3-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "2.0.2-alpha"
+version = "2.0.3-alpha"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.0.2-alpha"
+version = "2.0.3-alpha"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]


### PR DESCRIPTION
## Summary\n- bump crate version to 2.0.3-alpha after merged AI context automation updates\n- keep lockfile package version in sync\n\n## Validation\n- cargo check\n- cargo fmt --check\n- cargo clippy --all-targets -- -D warnings\n- cargo test\n