### PR TITLE
chore(release): bump version to 2.0.4-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "2.0.3-alpha"
+version = "2.0.4-alpha"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.0.3-alpha"
+version = "2.0.4-alpha"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]


### PR DESCRIPTION
Summary
- bump crate version to 2.0.4-alpha
- keep Cargo.lock package version in sync

Validation
- cargo check
- cargo test -q
- cargo clippy --all-targets -- -D warnings
