### PR TITLE
chore(release): stable v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "2.0.4-alpha"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.0.4-alpha"
+version = "2.1.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ brew install chafa  # or apt install libchafa-dev
 cargo install fileview --features chafa
 ```
 
+## Stability
+
+- Current channel: `stable` (`2.1.0`)
+- Stable promotion criteria are documented in `docs/STABILITY.md`.
+- As of 2026-02-04, criteria were satisfied and stable release was approved.
+
 ## Lua Plugin System
 
 Extend FileView with Lua scripts:
@@ -222,6 +228,7 @@ end)
 - [Comparison](docs/COMPARISON.md) - vs yazi, lf, ranger, nnn
 - [Benchmarks](docs/BENCHMARKS.md) - Performance data
 - [Security](docs/SECURITY.md) - Security model
+- [Stability](docs/STABILITY.md) - Release channel policy and alpha exit criteria
 
 ## License
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -166,6 +166,12 @@ brew install chafa  # または apt install libchafa-dev
 cargo install fileview --features chafa
 ```
 
+## 安定性
+
+- 現在のチャネル: `stable`（`2.1.0`）
+- stable移行条件は `docs/STABILITY.md` に明記しています。
+- 2026-02-04 時点で条件を満たし、stableリリース承認済みです。
+
 ## Lua プラグインシステム
 
 Lua スクリプトで FileView を拡張できます:
@@ -203,6 +209,7 @@ end)
 - [競合比較](docs/COMPARISON.md) - yazi, lf, ranger, nnn との比較
 - [ベンチマーク](docs/BENCHMARKS.md) - パフォーマンスデータ
 - [セキュリティ](docs/SECURITY.md) - セキュリティモデル
+- [安定性](docs/STABILITY.md) - リリースチャネル方針とalpha終了条件
 
 ## ライセンス
 

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -1,0 +1,27 @@
+# Stability Policy
+
+This project uses release channels:
+
+- `*-alpha`: Fast iteration, features may evolve quickly.
+- Stable (`x.y.z`): Recommended for general use.
+
+## Alpha Exit Criteria
+
+FileView can move from alpha to stable when all conditions are met:
+
+1. CI remains green for at least 2 consecutive release cycles.
+2. No critical incidents in those cycles:
+   - crash loops
+   - data-loss/corruption bugs
+   - security fixes requiring emergency release
+3. `cargo audit` is green under committed policy (`.cargo/audit.toml`), and any temporary ignores are documented.
+4. CLI behavior is compatibility-focused (no unannounced breaking changes in existing flags/actions).
+
+## Current Assessment (2026-02-04)
+
+- CI: green
+- Local quality gates: `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass
+- Security: `cargo audit -q` passes with documented policy
+- Critical bug scan: no active critical bug identified
+
+Based on this, the project is eligible for stable release.


### PR DESCRIPTION
## Summary
- release stable `v2.1.0` (remove alpha suffix)
- add explicit alpha-exit policy in `docs/STABILITY.md`
- update README/README_ja stability sections and docs links

## Critical bug / security checks
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q`
- `cargo audit -q`

All checks passed before PR creation.
