### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]


### PR DESCRIPTION
## Summary
- release v2.2.0
- includes AI workflow improvements merged in #119
- bump Cargo.toml/Cargo.lock version to 2.2.0

## Note
- GitHub Actions are currently blocked by billing limits in this repository.
- local checks could not be rerun due temporary crates.io DNS resolution issues in this environment.
