### PR TITLE
docs: add release policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ end)
 - [Benchmarks](docs/BENCHMARKS.md) - Performance data
 - [Security](docs/SECURITY.md) - Security model
 - [Stability](docs/STABILITY.md) - Release channel policy and alpha exit criteria
+- [Release Policy](docs/RELEASE_POLICY.md) - Versioning, cadence, and promotion rules
 
 ## License
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -237,6 +237,7 @@ end)
 - [ベンチマーク](docs/BENCHMARKS.md) - パフォーマンスデータ
 - [セキュリティ](docs/SECURITY.md) - セキュリティモデル
 - [安定性](docs/STABILITY.md) - リリースチャネル方針とalpha終了条件
+- [リリースポリシー](docs/RELEASE_POLICY.md) - バージョニングと運用ルール
 
 ## ライセンス
 

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -1,0 +1,60 @@
+# Release Policy
+
+## Goal
+
+リリースを「速さ」と「分かりやすさ」の両立で運用する。
+
+- 開発速度は落とさない
+- ユーザーには常に「今使うべき版」を明確に示す
+
+## Version Channels
+
+### Stable (`x.y.z`)
+- 一般ユーザー向けの推奨版
+- 互換性と安定性を優先
+
+### Pre-release (`x.y.z-alpha.N`, `x.y.z-rc.N`)
+- 早期検証向け
+- 破壊的変更や挙動変更を含む可能性あり
+
+## Cadence
+
+1. Stable は月1〜2回を基本
+2. 重大修正は patch (`x.y.z+1`) を即時リリース
+3. 細かな改善は pre-release に集約
+
+## Promotion Rules
+
+Stable 昇格前に以下を満たすこと:
+
+1. `cargo check`
+2. `cargo clippy --all-targets -- -D warnings`
+3. `cargo test`
+4. `cargo audit`（運用ポリシー込みで許容状態）
+5. 重大バグ（クラッシュ/データ破壊/緊急セキュリティ修正）が直近サイクルで発生していない
+
+## Tagging
+
+1. 各公開版に Git tag を付与（例: `v2.3.0`, `v2.3.1`）
+2. pre-release は suffix を含める（例: `v2.4.0-alpha.1`）
+3. superseded な版（例: 公開直後に置き換え）を `CHANGELOG.md` に明記
+
+## Communication Rules
+
+毎リリースで以下を更新:
+
+1. `CHANGELOG.md`
+2. `README.md`（必要なら推奨版や導線）
+3. `README_ja.md`
+
+## “Recommended Version” Policy
+
+- 常に最新 stable を推奨版とする
+- pre-release は検証目的として明示する
+
+## Practical Example
+
+- 開発中: `2.4.0-alpha.1` → `2.4.0-alpha.2`
+- 収束後: `2.4.0-rc.1`
+- 安定化完了: `2.4.0`（推奨版）
+- 緊急修正: `2.4.1`


### PR DESCRIPTION
## Summary
- add docs/RELEASE_POLICY.md
- define stable/pre-release channels and cadence
- add policy links to README and README_ja
