### PR TITLE
Release v2.2.2: narrow terminal icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-02-04
+
+### Changed
+
+- Narrow UI (`25-39` columns) でも Nerd Fonts のファイル/フォルダアイコンを表示するよう改善
+- ドキュメントの密度テーブルを実装仕様に合わせて更新
+
+
 ## [2.2.1] - 2026-02-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 description = "A minimal file tree UI for terminal emulators"
 authors = ["Hiro-Chiba"]

--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -332,7 +332,7 @@ FileView v2.0 supports terminals as narrow as **20 characters**:
 |-------|------|----------|
 | 80+ | Full | All features, icons, full preview |
 | 40-79 | Compact | Condensed status, partial preview |
-| 25-39 | Narrow | No icons, minimal status |
+| 25-39 | Narrow | Icons + minimal status |
 | 20-24 | Ultra | Essential info only |
 
 This makes FileView perfect for AI pair programming where Claude Code uses 80% of the screen.

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -83,7 +83,7 @@ pub enum UiDensity {
     Full,
     /// Compact mode (40-79 chars) - current compact display
     Compact,
-    /// Narrow mode (25-39 chars) - abbreviated icons, minimal status
+    /// Narrow mode (25-39 chars) - icons with minimal status
     Narrow,
     /// Ultra mode (20-24 chars) - minimal display for extreme narrow terminals
     Ultra,
@@ -102,7 +102,7 @@ impl UiDensity {
 
     /// Check if icons should be shown
     pub fn show_icons(&self) -> bool {
-        matches!(self, Self::Full | Self::Compact)
+        matches!(self, Self::Full | Self::Compact | Self::Narrow)
     }
 
     /// Check if full status bar should be shown

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -42,9 +42,9 @@ impl TreeColumns {
                 mark_width: 1,
                 git_indicator_width: 1,
                 indent_width: 1,
-                icon_width: 0, // No icons in narrow mode
-                max_filename_width: inner_width.saturating_sub(3),
-                show_icons: false,
+                icon_width: 2,
+                max_filename_width: inner_width.saturating_sub(6),
+                show_icons: true,
             },
             UiDensity::Compact => Self {
                 mark_width: 1,
@@ -301,6 +301,10 @@ mod tests {
 
         let cols = TreeColumns::new(UiDensity::Ultra, 20);
         assert!(!cols.show_icons);
+        assert_eq!(cols.indent_width, 1);
+
+        let cols = TreeColumns::new(UiDensity::Narrow, 30);
+        assert!(cols.show_icons);
         assert_eq!(cols.indent_width, 1);
     }
 


### PR DESCRIPTION
## Summary
- enable file/folder icons in Narrow density (25-39 columns)
- keep Ultra density icon-less to preserve readability
- update docs density table and add v2.2.2 changelog entry
- bump version to 2.2.2

## Verification
- cargo test --quiet