### PR TITLE
feat(ui): configurable help key highlight style

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -70,6 +70,7 @@ compress = "zip -r archive.zip $S"
 |----------|-------------|
 | `FILEVIEW_ICONS=0` | Disable icons |
 | `FILEVIEW_IMAGE_PROTOCOL` | Force image protocol |
+| `FILEVIEW_HELP_KEY_STYLE` | Help key style: `solid`, `outline`, `plain` |
 
 ## CLI Arguments
 

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -10,6 +10,8 @@ background = "default"    # Main background
 foreground = "white"      # Default text color
 selection = "blue"        # Selection highlight
 border = "gray"           # Border color
+help_key_fg = "black"     # Help popup key text color
+help_key_bg = "cyan"      # Help popup key background color
 
 [file_colors]
 directory = "blue"        # Directory color
@@ -141,3 +143,4 @@ untracked = "#bf616a"
 - Use 256-color palette (`color0`-`color255`) for precise control
 - Hex colors provide the most flexibility
 - Test your theme in different terminal emulators for consistency
+- Help key highlight style can be switched with `FILEVIEW_HELP_KEY_STYLE=solid|outline|plain`

--- a/examples/theme.toml
+++ b/examples/theme.toml
@@ -15,6 +15,8 @@ background = "default"
 foreground = "white"
 selection = "blue"
 border = "gray"
+help_key_fg = "black"
+help_key_bg = "cyan"
 
 [file_colors]
 # File type colors

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -624,6 +624,7 @@ CONFIG FILE:
 ENVIRONMENT:
     FILEVIEW_ICONS=0            Disable icons
     FILEVIEW_IMAGE_PROTOCOL     Force image protocol: auto, halfblocks, chafa, sixel, kitty, iterm2
+    FILEVIEW_HELP_KEY_STYLE     Help key style: solid (default), outline, plain
 
 KEYBINDINGS:
     j/↓         Move down

--- a/src/render/theme.rs
+++ b/src/render/theme.rs
@@ -54,6 +54,10 @@ pub struct BaseColors {
     pub warning: String,
     /// Info message color
     pub info: String,
+    /// Help key foreground color
+    pub help_key_fg: String,
+    /// Help key background color
+    pub help_key_bg: String,
 }
 
 impl Default for BaseColors {
@@ -69,6 +73,8 @@ impl Default for BaseColors {
             error: "red".to_string(),
             warning: "yellow".to_string(),
             info: "blue".to_string(),
+            help_key_fg: "black".to_string(),
+            help_key_bg: "cyan".to_string(),
         }
     }
 }
@@ -185,6 +191,8 @@ pub struct Theme {
     pub error: Color,
     pub warning: Color,
     pub info: Color,
+    pub help_key_fg: Color,
+    pub help_key_bg: Color,
 
     // File type colors
     pub directory: Color,
@@ -238,6 +246,8 @@ impl Theme {
             error: parse_color(&file.colors.error),
             warning: parse_color(&file.colors.warning),
             info: parse_color(&file.colors.info),
+            help_key_fg: parse_color(&file.colors.help_key_fg),
+            help_key_bg: parse_color(&file.colors.help_key_bg),
 
             // File type colors
             directory: parse_color(&file.file_colors.directory),


### PR DESCRIPTION
## Summary
- add FILEVIEW_HELP_KEY_STYLE with solid/outline/plain
- make help key colors themeable via help_key_fg / help_key_bg
- wire new theme colors into help popup rendering
- update configuration/theme docs and example theme

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --quiet
