### PR TITLE
docs(growth): scorecard + release sync + AI quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ cargo install fileview
 fv
 ```
 
+## 3-Min AI Workflow (Recommended)
+
+```bash
+# 1) Set up Claude MCP integration once
+fv init claude
+
+# 2) Generate compact context for AI
+fv --context-pack review --agent claude
+
+# 3) Resume previous AI session context
+fv --resume-ai-session
+```
+
+Useful docs:
+- [Claude Code Guide](docs/CLAUDE_CODE.md)
+- [Competitive Scorecard (weekly)](docs/COMPETITIVE_SCORECARD.md)
+- [Release Policy](docs/RELEASE_POLICY.md)
+
 ## Features
 
 | Feature | Description |

--- a/README_ja.md
+++ b/README_ja.md
@@ -32,6 +32,24 @@ cargo install fileview
 fv
 ```
 
+## 3分で始めるAIワークフロー（推奨）
+
+```bash
+# 1) Claude MCP連携を一度だけ設定
+fv init claude
+
+# 2) AI向けコンテキストを生成
+fv --context-pack review --agent claude
+
+# 3) 前回セッションを復元
+fv --resume-ai-session
+```
+
+関連ドキュメント:
+- [Claude Codeガイド](docs/CLAUDE_CODE_ja.md)
+- [競合スコアカード（週次更新）](docs/COMPETITIVE_SCORECARD.md)
+- [リリース方針](docs/RELEASE_POLICY.md)
+
 ## 機能
 
 | 機能 | 説明 |

--- a/docs/COMPETITIVE_SCORECARD.md
+++ b/docs/COMPETITIVE_SCORECARD.md
@@ -1,0 +1,77 @@
+# Competitive Scorecard
+
+Last updated: 2026-02-04
+
+This file tracks market position and execution metrics for `fileview` against core terminal file manager competitors.
+
+## Scope
+
+- Competitors: `yazi`, `lf`, `nnn`, `ranger`
+- Update cadence: weekly
+- Goal: move from niche AI-oriented utility to broadly trusted daily driver
+
+## Current Snapshot (2026-02-04)
+
+| Metric | fileview | yazi | lf | nnn | ranger |
+|---|---:|---:|---:|---:|---:|
+| GitHub stars | 0 | 32,179 | 9,026 | 21,191 | 16,834 |
+| GitHub forks | 0 | 701 | 359 | 798 | 923 |
+| Open issues | 0 | 73 | 66 | 2 | 921 |
+| Latest release tag | v2.2.2 | v26.1.22 | r41 | v5.1 | (no latest release API) |
+| crates.io downloads | 596 | - | - | - | - |
+
+Notes:
+- `fileview` now has release records for `v2.0.2-alpha` through `v2.2.2` to align tags and Releases.
+- `ranger` currently returns 404 for GitHub "latest release" API endpoint.
+
+## Product Position (Honest)
+
+| Axis | fileview today | Gap to close |
+|---|---|---|
+| AI workflow integration | Strong differentiator (MCP/context-pack/select flows) | Need broader awareness and case studies |
+| Zero-config onboarding | Strong | Keep startup and setup friction low |
+| Ecosystem/network effects | Weak | Grow contributors, examples, third-party coverage |
+| Community trust signals | Weak | Improve release notes, reliability signals, docs depth |
+| Power-user extensibility | Medium | Expand plugin references and recipes |
+
+## 90-Day Targets
+
+| KPI | Baseline | Target |
+|---|---:|---:|
+| GitHub stars | 0 | 150 |
+| External contributors (rolling 90d) | 0 | 10 |
+| crates.io weekly downloads | 596 (recent total snapshot) | 300+/week |
+| AI workflow case studies | 0 curated | 10 |
+| Release note coverage for new tags | partial before sync | 100% |
+
+## Weekly Review Template
+
+Copy this block every week:
+
+```md
+## Week YYYY-MM-DD
+- Product:
+  - shipped:
+  - regressions:
+- Growth:
+  - stars:
+  - downloads:
+  - contributors:
+- Competitive:
+  - yazi:
+  - lf:
+  - nnn:
+  - ranger:
+- Decision:
+  - double-down:
+  - de-prioritize:
+```
+
+## Source Links
+
+- fileview: <https://github.com/Hiro-Chiba/fileview>
+- yazi: <https://github.com/sxyazi/yazi>
+- lf: <https://github.com/gokcehan/lf>
+- nnn: <https://github.com/jarun/nnn>
+- ranger: <https://github.com/ranger/ranger>
+- crates.io fileview: <https://crates.io/crates/fileview>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,7 @@ FileView は「単体FMの機能競争」ではなく、**AI駆動開発の補�
 ## Current Position
 
 - Current channel: `stable`
-- Current version: `2.1.0`
+- Current version: `2.2.2`
 - Strength: MCP + context-pack + lightweight TUI
 - Gap to close: 認知/導入導線、AI専用ワークフローの完成度、継続利用ループ
 
@@ -36,6 +36,9 @@ FileView は「単体FMの機能競争」ではなく、**AI駆動開発の補�
 
 | Version | Date | Channel | Highlights |
 |---|---|---|---|
+| `v2.2.2` | 2026-02-04 | stable | Narrow (`25-39`) でもファイル/フォルダアイコン表示 |
+| `v2.2.1` | 2026-02-04 | stable | 公開フロー安定化（lock整合修正） |
+| `v2.2.0` | 2026-02-04 | stable | AI growth sprint1（後続で2.2.1に実運用移行） |
 | `v2.1.0` | 2026-02-04 | stable | stable昇格、alpha exit policy導入 |
 | `v2.0.4-alpha` | 2026-02-04 | alpha | 安定版直前の最終調整 |
 | `v2.0.3-alpha` | 2026-02-04 | alpha | AI context automation強化 |


### PR DESCRIPTION
## Summary
- add docs/COMPETITIVE_SCORECARD.md for weekly market/KPI tracking
- add 3-minute AI workflow section to README and README_ja
- update roadmap current version and release history (v2.2.0-v2.2.2)
- sync GitHub Releases for v2.0.2-alpha through v2.2.2

## Why
- improve external trust signals and discovery for AI-first positioning
- align tags, release history, and docs so users see current state quickly

## Validation
- docs-only change in repo; no runtime code paths changed
