### PR TITLE
chore(growth): add score loop + philosophy docs

### DIFF
--- a/.skill
+++ b/.skill
@@ -1,0 +1,45 @@
+# fileview-autopilot.skill
+
+name: fileview-autopilot
+description: "fileview開発の高速実行モード。品質確認、PR作成、マージ、リリースまでを最短で回す。"
+version: "1.0"
+language: "ja"
+
+defaults:
+  branch_from: "main"
+  run_checks:
+    - "cargo fmt --all -- --check"
+    - "cargo clippy --all-targets -- -D warnings"
+    - "cargo test --quiet"
+    - "cargo audit"
+  docs_sync:
+    - "README.md"
+    - "README_ja.md"
+    - "docs/ROADMAP.md"
+    - "docs/DEVELOPMENT_HISTORY.md"
+    - "CHANGELOG.md"
+
+workflow:
+  - "git statusを確認し、作業差分と現在ブランチを最初に報告する"
+  - "思想.md を常に参照し、20%ターミナル空間でのAI駆動開発支援を最優先する"
+  - "score.md の競合スコアを更新し、改善テーマを1つ決める"
+  - "必要なら main から作業ブランチを作成する"
+  - "scripts/ai_growth_loop.sh で品質/セキュリティチェックを回す"
+  - "実装後に run_checks を実行し、結果を要約する"
+  - "コミット・push・PR作成・CI確認を行う"
+  - "ユーザー指示があればマージ、タグ作成、cargo publishを実行する"
+  - "最後に残タスクを3行以内で提示する"
+
+release_policy:
+  - "安定版は vX.Y.Z"
+  - "先行版は vX.Y.Z-alpha"
+  - "GitHub Releasesとgit tagの不整合を残さない"
+
+safety:
+  - "破壊的コマンド（reset --hard / checkout -- / rm -rf）を使わない"
+  - "ユーザー未指示のrevertをしない"
+  - "CIが課金制限で動かない場合はローカル検証結果を明示する"
+
+note:
+  - "この .skill は運用ルール定義。Codex/Claudeの無限自動実行を強制するものではない。"
+  - "常時実行が必要な場合は cron/launchd/GitHub Actions で定期ジョブ化する。"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ fv --resume-ai-session
 Useful docs:
 - [Claude Code Guide](docs/CLAUDE_CODE.md)
 - [Competitive Scorecard (weekly)](docs/COMPETITIVE_SCORECARD.md)
+- [Current score snapshot](score.md)
+- [Product philosophy](思想.md)
 - [Release Policy](docs/RELEASE_POLICY.md)
 
 ## Features

--- a/README_ja.md
+++ b/README_ja.md
@@ -48,6 +48,8 @@ fv --resume-ai-session
 関連ドキュメント:
 - [Claude Codeガイド](docs/CLAUDE_CODE_ja.md)
 - [競合スコアカード（週次更新）](docs/COMPETITIVE_SCORECARD.md)
+- [現行スコアスナップショット](score.md)
+- [プロダクト思想](思想.md)
 - [リリース方針](docs/RELEASE_POLICY.md)
 
 ## 機能

--- a/score.md
+++ b/score.md
@@ -1,0 +1,49 @@
+# fileview Competitive Score (Snapshot)
+
+Updated: 2026-02-04
+
+## Score Model (100)
+
+- Product capability: 35
+- AI workflow fit (20% terminal constraint): 25
+- Reliability/release operation: 15
+- Ecosystem/community: 15
+- Growth momentum: 10
+
+## Current Scores (No Flattery)
+
+| Product | Total | Product | AI Fit | Reliability | Ecosystem | Momentum |
+|---|---:|---:|---:|---:|---:|---:|
+| yazi | 77 | 33 | 6 | 12 | 15 | 11 |
+| ranger | 67 | 29 | 4 | 13 | 14 | 7 |
+| nnn | 62 | 24 | 3 | 14 | 13 | 8 |
+| lf | 60 | 24 | 3 | 13 | 12 | 8 |
+| fileview | 55 | 22 | 18 | 10 | 2 | 3 |
+
+## Market Snapshot (latest successful fetch in this workspace)
+
+| Repo | Stars | Forks | Open Issues |
+|---|---:|---:|---:|
+| Hiro-Chiba/fileview | 0 | 0 | 0 |
+| sxyazi/yazi | 32,179 | 701 | 73 |
+| gokcehan/lf | 9,026 | 359 | 66 |
+| jarun/nnn | 21,191 | 798 | 2 |
+| ranger/ranger | 16,834 | 923 | 921 |
+
+## Gap Summary
+
+- fileview's strongest edge is AI workflow in narrow terminal space.
+- Largest gap is ecosystem trust signals (stars, third-party usage, contributor base).
+- 90-day objective: 55 -> 65 by compounding trust + adoption + AI-first UX quality.
+
+## Loop Rule
+
+Repeat this cycle:
+
+1. Market research update
+2. Implement one measurable improvement
+3. Re-score in this file
+4. Record before/after delta
+5. Repeat
+
+If no score delta appears for 2 cycles, pivot theme immediately.

--- a/scripts/ai_growth_loop.sh
+++ b/scripts/ai_growth_loop.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Single-cycle (default) or repeat mode for the growth loop.
+# Usage:
+#   scripts/ai_growth_loop.sh
+#   scripts/ai_growth_loop.sh --loop --sleep 1800
+
+LOOP=0
+SLEEP_SEC=1800
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --loop)
+      LOOP=1
+      shift
+      ;;
+    --sleep)
+      SLEEP_SEC="${2:-1800}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+run_cycle() {
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  echo "[ai-growth-loop] cycle start: ${ts}"
+
+  echo "[1/4] Quality checks"
+  cargo fmt --all -- --check
+  cargo clippy --all-targets -- -D warnings
+  cargo test --quiet
+  cargo audit || true
+
+  echo "[2/4] Competitive snapshot reminder"
+  echo "Update score.md with latest market metrics and deltas."
+
+  echo "[3/4] Implementation rule"
+  echo "Pick one improvement tied to narrow AI workflow in 20% terminal space."
+
+  echo "[4/4] Decision gate"
+  echo "Escalate only for major decisions listed in 思想.md."
+
+  echo "[ai-growth-loop] cycle done"
+}
+
+if [[ "${LOOP}" -eq 1 ]]; then
+  while true; do
+    run_cycle
+    echo "[ai-growth-loop] sleep ${SLEEP_SEC}s"
+    sleep "${SLEEP_SEC}"
+  done
+else
+  run_cycle
+fi

--- a/思想.md
+++ b/思想.md
@@ -1,0 +1,56 @@
+# fileview Product Philosophy
+
+Updated: 2026-02-04
+
+## North Star
+
+`fileview` is not trying to win by becoming a generic "everything file manager."
+
+It must win as:
+
+- the best companion for AI-driven development
+- in the remaining ~20% terminal space when tools like Claude Code/Codex CLI occupy most of the screen
+
+## Non-Negotiables
+
+1. Optimize for narrow terminals first.
+2. Prioritize AI workflow speed over feature vanity.
+3. Keep zero-config onboarding.
+4. Ship in small fast loops with measurable score impact.
+5. Preserve reliability: no destructive surprises.
+
+## What "Winning" Means
+
+- A developer can open `fileview` and become AI-productive in under 3 minutes.
+- Context gathering for AI review/debug is faster than manual shell workflows.
+- In split terminals, `fileview` remains readable and useful.
+- Release quality and docs clarity build trust over time.
+
+## Decision Gates (Only escalate major decisions)
+
+Escalate to human owner only when one of these is true:
+
+- Breaking change in CLI/MCP API
+- Potential data-loss risk
+- Stable release cut decision
+- Large architecture rewrite
+- Pricing/cost/legal/security policy change
+
+Everything else should be executed automatically in the loop.
+
+## Execution Loop
+
+1. Market research
+2. Implement smallest high-impact improvement
+3. Run quality/security checks
+4. Compare score delta in `score.md`
+5. Publish docs/history updates
+6. Repeat
+
+## Anti-Drift Reminder
+
+When in doubt, choose the option that improves:
+
+- narrow-screen AI workflow quality
+- time-to-context for reviews/debugging
+- trust signals (stability, docs, release hygiene)


### PR DESCRIPTION
## Summary
- add `score.md` with current competitive scoring snapshot and loop rule
- add `思想.md` to lock product north-star (AI dev companion in remaining 20% terminal space)
- add `.skill` autopilot runbook for repeatable execution
- add `scripts/ai_growth_loop.sh` for continuous quality+execution loop
- add links from README / README_ja to score and philosophy docs

## Validation
- scripts/ai_growth_loop.sh
  - cargo fmt --check: pass
  - cargo clippy: pass
  - cargo test: pass
  - cargo audit: warning in this environment due advisory-db lock on read-only path
