### PR TITLE
feat: add speed-oriented release-fast profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,7 @@ lto = true
 strip = true
 opt-level = "z"
 codegen-units = 1
+
+[profile.release-fast]
+inherits = "release"
+opt-level = 3

--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ cargo install fileview
 # With Chafa support (better image quality on basic terminals)
 brew install chafa  # or apt install libchafa-dev
 cargo install fileview --features chafa
+
+# Speed-optimized build (larger binary, better runtime performance)
+cargo install fileview --profile release-fast
 ```
 
 ## Stability


### PR DESCRIPTION
## Summary
- `[profile.release-fast]` プロファイルを追加（`inherits = "release"` + `opt-level = 3`）
- README の Installation Options セクションにビルドコマンドを追記

## Details
既存の `[profile.release]`（`opt-level = "z"`、サイズ最小化）はそのまま維持し、ランタイムパフォーマンス重視の `release-fast` プロファイルを追加。LTO / strip / codegen-units=1 は release から継承し、opt-level のみ 3 に上書き。

Closes #154

## Test plan
- [x] `cargo build --profile release-fast` が成功
- [x] `cargo test` — 346 テスト全パス
- [x] `cargo clippy --profile release-fast` — 警告なし