### PR TITLE
perf: move heavy preview generation off the UI thread

### DIFF
--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -293,8 +293,8 @@ pub fn run_app(
             needs_redraw = true;
         }
 
-        // Poll for completed async image loads
-        if preview.poll_image_result(image_picker, &mut state) {
+        // Poll for completed async preview loads (worker + image loader)
+        if preview.poll_preview_result(image_picker, &mut state) {
             needs_redraw = true;
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8,6 +8,7 @@ mod config_file;
 mod event_loop;
 mod image_loader;
 mod preview;
+mod preview_worker;
 mod render;
 mod video;
 

--- a/src/app/preview.rs
+++ b/src/app/preview.rs
@@ -5,10 +5,13 @@ use std::path::PathBuf;
 
 use image::GenericImageView;
 
-use crate::app::video::{extract_thumbnail, find_ffprobe, get_metadata, is_video_file};
+use crate::app::preview_worker::{
+    CachedPreview, PreviewCache, PreviewKind, PreviewPayload, PreviewWorker,
+};
+use crate::app::video::{extract_thumbnail, is_video_file};
 use crate::app::ImageLoader;
 use crate::core::AppState;
-use crate::git::{self, FileStatus};
+use crate::git::FileStatus;
 use crate::render::{
     find_pdftoppm, is_archive_file, is_binary_file, is_image_file, is_pdf_file, is_tar_gz_file,
     is_text_file, ArchivePreview, CustomPreview, DiffPreview, DirectoryInfo, HexPreview,
@@ -34,6 +37,14 @@ pub struct PreviewState {
     pub loading_image_path: Option<PathBuf>,
     /// Video path currently loading thumbnail
     pub loading_video_thumbnail: Option<PathBuf>,
+    /// Background preview worker
+    preview_worker: PreviewWorker,
+    /// LRU preview cache
+    preview_cache: PreviewCache,
+    /// Whether a preview is currently being generated in the background
+    pub is_loading: bool,
+    /// Serial number of the latest preview request
+    pending_serial: u64,
 }
 
 impl PreviewState {
@@ -81,6 +92,7 @@ impl PreviewState {
         }
 
         self.last_path = path.cloned();
+        self.is_loading = false;
 
         let Some(path) = path else {
             self.clear_all();
@@ -113,9 +125,9 @@ impl PreviewState {
         }
 
         if path.is_dir() {
-            // Load directory info
-            if let Ok(info) = DirectoryInfo::from_path(path) {
-                self.dir_info = Some(info);
+            // Check cache first
+            if let Some(CachedPreview::Directory(ref info)) = self.preview_cache.get(path) {
+                self.dir_info = Some(info.clone());
                 self.text = None;
                 self.image = None;
                 self.hex = None;
@@ -123,7 +135,17 @@ impl PreviewState {
                 self.pdf = None;
                 self.diff = None;
                 self.custom = None;
+                return;
             }
+            // Dispatch to worker
+            self.clear_all();
+            self.is_loading = true;
+            self.pending_serial = self.preview_worker.request(
+                path.to_path_buf(),
+                PreviewKind::Directory,
+                None,
+                None,
+            );
         } else if is_text_file(path) {
             // Check if file has git changes - if so, show diff instead
             let git_status = state
@@ -138,50 +160,57 @@ impl PreviewState {
             );
 
             if has_changes {
-                // Try to get diff for changed files
-                if let Some(ref git) = state.git_status {
-                    let repo_root = git.repo_root();
-                    // Try staged diff first, then unstaged
-                    let diff = git::get_diff(repo_root, path, true)
-                        .or_else(|| git::get_diff(repo_root, path, false));
-
-                    if let Some(file_diff) = diff {
-                        if !file_diff.is_empty() {
-                            self.diff = Some(DiffPreview::new(file_diff));
-                            self.text = None;
-                            self.image = None;
-                            self.dir_info = None;
-                            self.hex = None;
-                            self.archive = None;
-                            self.pdf = None;
-                            self.custom = None;
-                            return;
-                        }
-                    }
-                }
-            }
-
-            // Fall back to regular text preview
-            match std::fs::read_to_string(path) {
-                Ok(content) => {
-                    self.text = Some(TextPreview::with_highlighting(&content, path));
+                // Check cache for diff
+                if let Some(CachedPreview::Diff(ref dp)) = self.preview_cache.get(path) {
+                    self.diff = Some(dp.clone());
+                    self.text = None;
                     self.image = None;
                     self.dir_info = None;
                     self.hex = None;
                     self.archive = None;
                     self.pdf = None;
-                    self.diff = None;
                     self.custom = None;
+                    return;
                 }
-                Err(e) => {
-                    state.set_message(format!("Failed: preview - {}", e));
+                // Dispatch diff to worker
+                if let Some(ref git) = state.git_status {
+                    let repo_root = git.repo_root().to_path_buf();
                     self.clear_all();
+                    self.is_loading = true;
+                    self.pending_serial = self.preview_worker.request(
+                        path.to_path_buf(),
+                        PreviewKind::Diff,
+                        Some(repo_root),
+                        Some(git_status),
+                    );
+                    return;
                 }
             }
+
+            // Check cache for text
+            if let Some(CachedPreview::Text(ref tp)) = self.preview_cache.get(path) {
+                self.text = Some(tp.clone());
+                self.image = None;
+                self.dir_info = None;
+                self.hex = None;
+                self.archive = None;
+                self.pdf = None;
+                self.diff = None;
+                self.custom = None;
+                return;
+            }
+            // Dispatch text to worker
+            self.clear_all();
+            self.is_loading = true;
+            self.pending_serial = self.preview_worker.request(
+                path.to_path_buf(),
+                PreviewKind::Text,
+                None,
+                None,
+            );
         } else if is_image_file(path) {
-            // Start async image loading (non-blocking)
+            // Start async image loading (non-blocking) — existing ImageLoader
             if self.image_loader.request(path.to_path_buf()) {
-                // Clear current preview while loading
                 self.image = None;
                 self.text = None;
                 self.dir_info = None;
@@ -194,84 +223,39 @@ impl PreviewState {
                 self.loading_image_path = Some(path.to_path_buf());
             }
         } else if is_video_file(path) {
-            // Video preview - requires ffprobe for metadata
-            if find_ffprobe().is_some() {
-                match get_metadata(path) {
-                    Ok(metadata) => {
-                        let mut video_preview = VideoPreview::new(path, metadata);
-
-                        // Try to extract thumbnail
-                        match extract_thumbnail(path) {
-                            Ok(thumb_path) => {
-                                // Request thumbnail loading
-                                if self.image_loader.request(thumb_path.clone()) {
-                                    self.loading_video_thumbnail = Some(path.to_path_buf());
-                                }
-                            }
-                            Err(e) => {
-                                video_preview.thumbnail_error =
-                                    Some(format!("Failed to extract: {}", e));
-                            }
-                        }
-
-                        self.video = Some(video_preview);
-                        self.text = None;
-                        self.image = None;
-                        self.dir_info = None;
-                        self.hex = None;
-                        self.archive = None;
-                        self.pdf = None;
-                        self.diff = None;
-                        self.custom = None;
-                    }
-                    Err(e) => {
-                        state.set_message(format!("Failed: video preview - {}", e));
-                        // Fall back to hex preview
-                        self.load_hex_fallback(path, state);
-                    }
-                }
-            } else {
-                // ffprobe not installed - show message and fall back to hex preview
-                state.set_message("Video preview requires ffprobe (ffmpeg)");
-                self.load_hex_fallback(path, state);
+            // Dispatch video metadata to worker
+            self.clear_all();
+            self.is_loading = true;
+            self.pending_serial = self.preview_worker.request(
+                path.to_path_buf(),
+                PreviewKind::VideoMeta,
+                None,
+                None,
+            );
+        } else if is_tar_gz_file(path) || is_archive_file(path) {
+            // Check cache for archive
+            if let Some(CachedPreview::Archive(ref ap)) = self.preview_cache.get(path) {
+                self.archive = Some(ap.clone());
+                self.text = None;
+                self.image = None;
+                self.dir_info = None;
+                self.hex = None;
+                self.pdf = None;
+                self.diff = None;
+                self.custom = None;
+                return;
             }
-        } else if is_tar_gz_file(path) {
-            // Handle tar.gz files separately (before is_archive_file check)
-            match ArchivePreview::load_tar_gz(path) {
-                Ok(archive) => {
-                    self.archive = Some(archive);
-                    self.text = None;
-                    self.image = None;
-                    self.dir_info = None;
-                    self.hex = None;
-                    self.pdf = None;
-                    self.diff = None;
-                    self.custom = None;
-                }
-                Err(e) => {
-                    state.set_message(format!("Failed: preview - {}", e));
-                    self.clear_all();
-                }
-            }
-        } else if is_archive_file(path) {
-            match ArchivePreview::load_zip(path) {
-                Ok(archive) => {
-                    self.archive = Some(archive);
-                    self.text = None;
-                    self.image = None;
-                    self.dir_info = None;
-                    self.hex = None;
-                    self.pdf = None;
-                    self.diff = None;
-                    self.custom = None;
-                }
-                Err(e) => {
-                    state.set_message(format!("Failed: preview - {}", e));
-                    self.clear_all();
-                }
-            }
+            // Dispatch archive to worker
+            self.clear_all();
+            self.is_loading = true;
+            self.pending_serial = self.preview_worker.request(
+                path.to_path_buf(),
+                PreviewKind::Archive,
+                None,
+                None,
+            );
         } else if is_pdf_file(path) {
-            // PDF preview - requires pdftoppm (poppler-utils)
+            // PDF preview — stays synchronous (Picker is not Send)
             if find_pdftoppm().is_some() {
                 if let Some(ref mut picker) = image_picker {
                     match PdfPreview::load(path, 1, picker) {
@@ -287,21 +271,18 @@ impl PreviewState {
                         }
                         Err(e) => {
                             state.set_message(format!("Failed: preview - {}", e));
-                            // Fall back to hex preview
                             self.load_hex_fallback(path, state);
                         }
                     }
                 } else {
-                    // No image picker available - fall back to hex preview
                     self.load_hex_fallback(path, state);
                 }
             } else {
-                // pdftoppm not installed - show message and fall back to hex preview
                 state.set_message("PDF preview requires pdftoppm (poppler-utils)");
                 self.load_hex_fallback(path, state);
             }
         } else if is_binary_file(path) || path.is_file() {
-            // Binary file or unknown type - show hex preview
+            // Hex preview — stays synchronous (only 4KB, fast enough)
             match HexPreview::load(path) {
                 Ok(hex) => {
                     self.hex = Some(hex);
@@ -356,19 +337,111 @@ impl PreviewState {
             || self.video.is_some()
     }
 
-    /// Poll for completed image load results
+    /// Poll for completed preview results (both preview worker and image loader).
     ///
-    /// This should be called in the main event loop to receive
-    /// asynchronously loaded images.
-    ///
-    /// Returns true if an image was successfully loaded.
-    pub fn poll_image_result(
+    /// This should be called every iteration of the main event loop.
+    /// Returns true if any preview was updated (caller should set needs_redraw).
+    pub fn poll_preview_result(
         &mut self,
         image_picker: &mut Option<Picker>,
         state: &mut AppState,
     ) -> bool {
+        let mut changed = false;
+
+        // --- Poll preview worker ---
+        if let Some(response) = self.preview_worker.try_recv() {
+            // Last-request-wins: ignore stale results
+            if response.serial == self.pending_serial
+                && self.last_path.as_ref() == Some(&response.path)
+            {
+                self.is_loading = false;
+                match response.payload {
+                    Ok(payload) => {
+                        match payload {
+                            PreviewPayload::Text(tp) => {
+                                self.preview_cache.insert(
+                                    response.path,
+                                    CachedPreview::Text(tp.clone()),
+                                );
+                                self.text = Some(tp);
+                            }
+                            PreviewPayload::Diff(dp) => {
+                                self.preview_cache.insert(
+                                    response.path,
+                                    CachedPreview::Diff(dp.clone()),
+                                );
+                                self.diff = Some(dp);
+                            }
+                            PreviewPayload::Directory(di) => {
+                                self.preview_cache.insert(
+                                    response.path,
+                                    CachedPreview::Directory(di.clone()),
+                                );
+                                self.dir_info = Some(di);
+                            }
+                            PreviewPayload::Archive(ap) => {
+                                self.preview_cache.insert(
+                                    response.path,
+                                    CachedPreview::Archive(ap.clone()),
+                                );
+                                self.archive = Some(ap);
+                            }
+                            PreviewPayload::VideoMeta(metadata) => {
+                                let path = self.last_path.clone().unwrap();
+                                let mut video_preview = VideoPreview::new(&path, metadata);
+
+                                // Try to extract thumbnail and load via ImageLoader
+                                match extract_thumbnail(&path) {
+                                    Ok(thumb_path) => {
+                                        if self.image_loader.request(thumb_path) {
+                                            self.loading_video_thumbnail = Some(path);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        video_preview.thumbnail_error =
+                                            Some(format!("Failed to extract: {}", e));
+                                    }
+                                }
+
+                                self.video = Some(video_preview);
+                            }
+                        }
+                        changed = true;
+                    }
+                    Err(msg) => {
+                        // Diff failure falls back to text
+                        if msg == "No diff available" {
+                            // Re-request as text preview
+                            self.is_loading = true;
+                            self.pending_serial = self.preview_worker.request(
+                                self.last_path.as_ref().unwrap().clone(),
+                                PreviewKind::Text,
+                                None,
+                                None,
+                            );
+                        } else if msg.starts_with("Video preview requires") {
+                            state.set_message(msg);
+                            if let Some(ref path) = self.last_path.clone() {
+                                self.load_hex_fallback(path, state);
+                            }
+                            changed = true;
+                        } else {
+                            state.set_message(msg);
+                            // For video meta errors, fall back to hex
+                            if let Some(ref path) = self.last_path.clone() {
+                                if is_video_file(path) {
+                                    self.load_hex_fallback(path, state);
+                                }
+                            }
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Poll image loader (same as old poll_image_result) ---
         if let Some(result) = self.image_loader.try_recv() {
-            // Check if this is for regular image preview
             if self.loading_image_path.as_ref() == Some(&result.path) {
                 self.loading_image_path = None;
 
@@ -382,18 +455,14 @@ impl PreviewState {
                                 height,
                                 protocol,
                             });
-                            return true;
+                            changed = true;
                         }
                     }
                     Err(e) => {
                         state.set_message(format!("Failed: preview - {}", e));
                     }
                 }
-            }
-            // Check if this is for video thumbnail
-            else if self.loading_video_thumbnail.is_some() {
-                // The result path is the thumbnail path, not the video path
-                // But we need to attach it to the current video preview
+            } else if self.loading_video_thumbnail.is_some() {
                 if let Some(ref mut video) = self.video {
                     match result.result {
                         Ok(dyn_img) => {
@@ -406,7 +475,7 @@ impl PreviewState {
                                     protocol,
                                 });
                                 self.loading_video_thumbnail = None;
-                                return true;
+                                changed = true;
                             }
                         }
                         Err(e) => {
@@ -417,7 +486,8 @@ impl PreviewState {
                 }
             }
         }
-        false
+
+        changed
     }
 
     /// Check if an image is currently being loaded

--- a/src/app/preview.rs
+++ b/src/app/preview.rs
@@ -140,12 +140,9 @@ impl PreviewState {
             // Dispatch to worker
             self.clear_all();
             self.is_loading = true;
-            self.pending_serial = self.preview_worker.request(
-                path.to_path_buf(),
-                PreviewKind::Directory,
-                None,
-                None,
-            );
+            self.pending_serial =
+                self.preview_worker
+                    .request(path.to_path_buf(), PreviewKind::Directory, None, None);
         } else if is_text_file(path) {
             // Check if file has git changes - if so, show diff instead
             let git_status = state
@@ -202,12 +199,9 @@ impl PreviewState {
             // Dispatch text to worker
             self.clear_all();
             self.is_loading = true;
-            self.pending_serial = self.preview_worker.request(
-                path.to_path_buf(),
-                PreviewKind::Text,
-                None,
-                None,
-            );
+            self.pending_serial =
+                self.preview_worker
+                    .request(path.to_path_buf(), PreviewKind::Text, None, None);
         } else if is_image_file(path) {
             // Start async image loading (non-blocking) — existing ImageLoader
             if self.image_loader.request(path.to_path_buf()) {
@@ -226,12 +220,9 @@ impl PreviewState {
             // Dispatch video metadata to worker
             self.clear_all();
             self.is_loading = true;
-            self.pending_serial = self.preview_worker.request(
-                path.to_path_buf(),
-                PreviewKind::VideoMeta,
-                None,
-                None,
-            );
+            self.pending_serial =
+                self.preview_worker
+                    .request(path.to_path_buf(), PreviewKind::VideoMeta, None, None);
         } else if is_tar_gz_file(path) || is_archive_file(path) {
             // Check cache for archive
             if let Some(CachedPreview::Archive(ref ap)) = self.preview_cache.get(path) {
@@ -248,12 +239,9 @@ impl PreviewState {
             // Dispatch archive to worker
             self.clear_all();
             self.is_loading = true;
-            self.pending_serial = self.preview_worker.request(
-                path.to_path_buf(),
-                PreviewKind::Archive,
-                None,
-                None,
-            );
+            self.pending_serial =
+                self.preview_worker
+                    .request(path.to_path_buf(), PreviewKind::Archive, None, None);
         } else if is_pdf_file(path) {
             // PDF preview — stays synchronous (Picker is not Send)
             if find_pdftoppm().is_some() {
@@ -359,31 +347,23 @@ impl PreviewState {
                     Ok(payload) => {
                         match payload {
                             PreviewPayload::Text(tp) => {
-                                self.preview_cache.insert(
-                                    response.path,
-                                    CachedPreview::Text(tp.clone()),
-                                );
+                                self.preview_cache
+                                    .insert(response.path, CachedPreview::Text(tp.clone()));
                                 self.text = Some(tp);
                             }
                             PreviewPayload::Diff(dp) => {
-                                self.preview_cache.insert(
-                                    response.path,
-                                    CachedPreview::Diff(dp.clone()),
-                                );
+                                self.preview_cache
+                                    .insert(response.path, CachedPreview::Diff(dp.clone()));
                                 self.diff = Some(dp);
                             }
                             PreviewPayload::Directory(di) => {
-                                self.preview_cache.insert(
-                                    response.path,
-                                    CachedPreview::Directory(di.clone()),
-                                );
+                                self.preview_cache
+                                    .insert(response.path, CachedPreview::Directory(di.clone()));
                                 self.dir_info = Some(di);
                             }
                             PreviewPayload::Archive(ap) => {
-                                self.preview_cache.insert(
-                                    response.path,
-                                    CachedPreview::Archive(ap.clone()),
-                                );
+                                self.preview_cache
+                                    .insert(response.path, CachedPreview::Archive(ap.clone()));
                                 self.archive = Some(ap);
                             }
                             PreviewPayload::VideoMeta(metadata) => {

--- a/src/app/preview_worker.rs
+++ b/src/app/preview_worker.rs
@@ -80,9 +80,11 @@ impl PreviewWorker {
         while let Ok(req) = request_rx.recv() {
             let payload = match req.kind {
                 PreviewKind::Text => Self::generate_text(&req.path),
-                PreviewKind::Diff => {
-                    Self::generate_diff(&req.path, req.git_repo_root.as_deref(), req.git_file_status)
-                }
+                PreviewKind::Diff => Self::generate_diff(
+                    &req.path,
+                    req.git_repo_root.as_deref(),
+                    req.git_file_status,
+                ),
                 PreviewKind::Directory => Self::generate_directory(&req.path),
                 PreviewKind::Archive => Self::generate_archive(&req.path),
                 PreviewKind::VideoMeta => Self::generate_video_meta(&req.path),
@@ -101,8 +103,8 @@ impl PreviewWorker {
     }
 
     fn generate_text(path: &Path) -> Result<PreviewPayload, String> {
-        let content = std::fs::read_to_string(path)
-            .map_err(|e| format!("Failed: preview - {}", e))?;
+        let content =
+            std::fs::read_to_string(path).map_err(|e| format!("Failed: preview - {}", e))?;
         let preview = TextPreview::with_highlighting(&content, path);
         Ok(PreviewPayload::Text(preview))
     }
@@ -114,8 +116,8 @@ impl PreviewWorker {
     ) -> Result<PreviewPayload, String> {
         let repo_root = repo_root.ok_or_else(|| "No git repo root".to_string())?;
         // Try staged diff first, then unstaged
-        let diff = git::get_diff(repo_root, path, true)
-            .or_else(|| git::get_diff(repo_root, path, false));
+        let diff =
+            git::get_diff(repo_root, path, true).or_else(|| git::get_diff(repo_root, path, false));
 
         match diff {
             Some(file_diff) if !file_diff.is_empty() => {
@@ -154,7 +156,13 @@ impl PreviewWorker {
     }
 
     /// Send a preview request, returns the serial number assigned.
-    pub fn request(&mut self, req_path: PathBuf, kind: PreviewKind, git_repo_root: Option<PathBuf>, git_file_status: Option<FileStatus>) -> u64 {
+    pub fn request(
+        &mut self,
+        req_path: PathBuf,
+        kind: PreviewKind,
+        git_repo_root: Option<PathBuf>,
+        git_file_status: Option<FileStatus>,
+    ) -> u64 {
         self.current_serial += 1;
         let serial = self.current_serial;
         let _ = self.request_tx.send(PreviewRequest {

--- a/src/app/preview_worker.rs
+++ b/src/app/preview_worker.rs
@@ -1,0 +1,324 @@
+//! Background preview worker using std::thread and mpsc channels
+//!
+//! Moves heavy preview generation (text highlighting, git diff, directory scan,
+//! archive listing, video metadata) off the UI thread to prevent frame drops.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread::{self, JoinHandle};
+
+use crate::app::video::{find_ffprobe, get_metadata, VideoMetadata};
+use crate::git::{self, FileStatus};
+use crate::render::{
+    is_archive_file, is_tar_gz_file, ArchivePreview, DiffPreview, DirectoryInfo, TextPreview,
+};
+
+/// What kind of preview to generate
+#[derive(Debug, Clone)]
+pub enum PreviewKind {
+    Text,
+    Diff,
+    Directory,
+    Archive,
+    VideoMeta,
+}
+
+/// Request sent to the worker thread
+pub struct PreviewRequest {
+    pub path: PathBuf,
+    pub kind: PreviewKind,
+    pub serial: u64,
+    /// For Diff: git repo root
+    pub git_repo_root: Option<PathBuf>,
+    /// For Diff: file status
+    pub git_file_status: Option<FileStatus>,
+}
+
+/// Payload returned by the worker
+pub enum PreviewPayload {
+    Text(TextPreview),
+    Diff(DiffPreview),
+    Directory(DirectoryInfo),
+    Archive(ArchivePreview),
+    VideoMeta(VideoMetadata),
+}
+
+/// Response from the worker thread
+pub struct PreviewResponse {
+    pub path: PathBuf,
+    pub serial: u64,
+    pub payload: Result<PreviewPayload, String>,
+}
+
+/// Background preview worker
+pub struct PreviewWorker {
+    request_tx: Sender<PreviewRequest>,
+    result_rx: Receiver<PreviewResponse>,
+    _worker: JoinHandle<()>,
+    current_serial: u64,
+}
+
+impl PreviewWorker {
+    pub fn new() -> Self {
+        let (request_tx, request_rx) = mpsc::channel::<PreviewRequest>();
+        let (result_tx, result_rx) = mpsc::channel::<PreviewResponse>();
+
+        let worker = thread::spawn(move || {
+            Self::worker_loop(request_rx, result_tx);
+        });
+
+        Self {
+            request_tx,
+            result_rx,
+            _worker: worker,
+            current_serial: 0,
+        }
+    }
+
+    fn worker_loop(request_rx: Receiver<PreviewRequest>, result_tx: Sender<PreviewResponse>) {
+        while let Ok(req) = request_rx.recv() {
+            let payload = match req.kind {
+                PreviewKind::Text => Self::generate_text(&req.path),
+                PreviewKind::Diff => {
+                    Self::generate_diff(&req.path, req.git_repo_root.as_deref(), req.git_file_status)
+                }
+                PreviewKind::Directory => Self::generate_directory(&req.path),
+                PreviewKind::Archive => Self::generate_archive(&req.path),
+                PreviewKind::VideoMeta => Self::generate_video_meta(&req.path),
+            };
+
+            let response = PreviewResponse {
+                path: req.path,
+                serial: req.serial,
+                payload,
+            };
+
+            if result_tx.send(response).is_err() {
+                break;
+            }
+        }
+    }
+
+    fn generate_text(path: &Path) -> Result<PreviewPayload, String> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("Failed: preview - {}", e))?;
+        let preview = TextPreview::with_highlighting(&content, path);
+        Ok(PreviewPayload::Text(preview))
+    }
+
+    fn generate_diff(
+        path: &Path,
+        repo_root: Option<&Path>,
+        _status: Option<FileStatus>,
+    ) -> Result<PreviewPayload, String> {
+        let repo_root = repo_root.ok_or_else(|| "No git repo root".to_string())?;
+        // Try staged diff first, then unstaged
+        let diff = git::get_diff(repo_root, path, true)
+            .or_else(|| git::get_diff(repo_root, path, false));
+
+        match diff {
+            Some(file_diff) if !file_diff.is_empty() => {
+                Ok(PreviewPayload::Diff(DiffPreview::new(file_diff)))
+            }
+            _ => Err("No diff available".to_string()),
+        }
+    }
+
+    fn generate_directory(path: &Path) -> Result<PreviewPayload, String> {
+        DirectoryInfo::from_path(path)
+            .map(PreviewPayload::Directory)
+            .map_err(|e| format!("Failed: directory preview - {}", e))
+    }
+
+    fn generate_archive(path: &Path) -> Result<PreviewPayload, String> {
+        let result = if is_tar_gz_file(path) {
+            ArchivePreview::load_tar_gz(path)
+        } else if is_archive_file(path) {
+            ArchivePreview::load_zip(path)
+        } else {
+            return Err("Not an archive file".to_string());
+        };
+        result
+            .map(PreviewPayload::Archive)
+            .map_err(|e| format!("Failed: preview - {}", e))
+    }
+
+    fn generate_video_meta(path: &Path) -> Result<PreviewPayload, String> {
+        if find_ffprobe().is_none() {
+            return Err("Video preview requires ffprobe (ffmpeg)".to_string());
+        }
+        get_metadata(path)
+            .map(PreviewPayload::VideoMeta)
+            .map_err(|e| format!("Failed: video preview - {}", e))
+    }
+
+    /// Send a preview request, returns the serial number assigned.
+    pub fn request(&mut self, req_path: PathBuf, kind: PreviewKind, git_repo_root: Option<PathBuf>, git_file_status: Option<FileStatus>) -> u64 {
+        self.current_serial += 1;
+        let serial = self.current_serial;
+        let _ = self.request_tx.send(PreviewRequest {
+            path: req_path,
+            kind,
+            serial,
+            git_repo_root,
+            git_file_status,
+        });
+        serial
+    }
+
+    /// Non-blocking poll for a completed result.
+    pub fn try_recv(&self) -> Option<PreviewResponse> {
+        self.result_rx.try_recv().ok()
+    }
+
+    /// Current serial number (latest request).
+    #[cfg(test)]
+    pub fn current_serial(&self) -> u64 {
+        self.current_serial
+    }
+}
+
+impl Default for PreviewWorker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LRU Preview Cache
+// ---------------------------------------------------------------------------
+
+/// Cached preview data (only types that are Send + relatively cheap to store)
+pub enum CachedPreview {
+    Text(TextPreview),
+    Diff(DiffPreview),
+    Directory(DirectoryInfo),
+    Archive(ArchivePreview),
+}
+
+pub struct PreviewCache {
+    entries: VecDeque<(PathBuf, CachedPreview)>,
+    max_size: usize,
+}
+
+impl PreviewCache {
+    pub fn new(max_size: usize) -> Self {
+        Self {
+            entries: VecDeque::with_capacity(max_size),
+            max_size,
+        }
+    }
+
+    /// Look up a cached preview. Returns None on miss.
+    pub fn get(&mut self, path: &Path) -> Option<&CachedPreview> {
+        // Find the index, move to front for LRU
+        let idx = self.entries.iter().position(|(p, _)| p == path)?;
+        let entry = self.entries.remove(idx)?;
+        self.entries.push_front(entry);
+        self.entries.front().map(|(_, c)| c)
+    }
+
+    /// Insert a preview into the cache.
+    pub fn insert(&mut self, path: PathBuf, preview: CachedPreview) {
+        // Remove existing entry for same path
+        self.entries.retain(|(p, _)| p != &path);
+        self.entries.push_front((path, preview));
+        while self.entries.len() > self.max_size {
+            self.entries.pop_back();
+        }
+    }
+}
+
+impl Default for PreviewCache {
+    fn default() -> Self {
+        Self::new(32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_preview_worker_creation() {
+        let worker = PreviewWorker::new();
+        assert_eq!(worker.current_serial(), 0);
+        assert!(worker.try_recv().is_none());
+    }
+
+    #[test]
+    fn test_preview_cache_insert_and_get() {
+        let mut cache = PreviewCache::new(3);
+        let path = PathBuf::from("/tmp/test.txt");
+        let info = DirectoryInfo {
+            name: "test".to_string(),
+            file_count: 1,
+            dir_count: 0,
+            hidden_count: 0,
+            total_size: 100,
+        };
+        cache.insert(path.clone(), CachedPreview::Directory(info));
+        assert!(cache.get(&path).is_some());
+    }
+
+    #[test]
+    fn test_preview_cache_eviction() {
+        let mut cache = PreviewCache::new(2);
+        for i in 0..3 {
+            let path = PathBuf::from(format!("/tmp/test{}.txt", i));
+            let info = DirectoryInfo {
+                name: format!("test{}", i),
+                file_count: i,
+                dir_count: 0,
+                hidden_count: 0,
+                total_size: 0,
+            };
+            cache.insert(path, CachedPreview::Directory(info));
+        }
+        // First entry should be evicted
+        assert!(cache.get(Path::new("/tmp/test0.txt")).is_none());
+        assert!(cache.get(Path::new("/tmp/test1.txt")).is_some());
+        assert!(cache.get(Path::new("/tmp/test2.txt")).is_some());
+    }
+
+    #[test]
+    fn test_preview_cache_lru_ordering() {
+        let mut cache = PreviewCache::new(2);
+        let path1 = PathBuf::from("/tmp/a.txt");
+        let path2 = PathBuf::from("/tmp/b.txt");
+
+        let mk = |name: &str| {
+            CachedPreview::Directory(DirectoryInfo {
+                name: name.to_string(),
+                file_count: 0,
+                dir_count: 0,
+                hidden_count: 0,
+                total_size: 0,
+            })
+        };
+
+        cache.insert(path1.clone(), mk("a"));
+        cache.insert(path2.clone(), mk("b"));
+
+        // Access path1 to make it most recently used
+        let _ = cache.get(&path1);
+
+        // Insert path3 - should evict path2 (least recently used)
+        let path3 = PathBuf::from("/tmp/c.txt");
+        cache.insert(path3.clone(), mk("c"));
+
+        assert!(cache.get(&path1).is_some());
+        assert!(cache.get(&path2).is_none());
+        assert!(cache.get(&path3).is_some());
+    }
+
+    #[test]
+    fn test_worker_request_increments_serial() {
+        let mut worker = PreviewWorker::new();
+        let s1 = worker.request(PathBuf::from("/tmp/a"), PreviewKind::Directory, None, None);
+        let s2 = worker.request(PathBuf::from("/tmp/b"), PreviewKind::Directory, None, None);
+        assert_eq!(s1, 1);
+        assert_eq!(s2, 2);
+    }
+}

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -81,6 +81,12 @@ fn render_fullscreen_preview(
         render_hex_preview(frame, hp, size, &title, false);
     } else if let Some(ref ap) = ctx.preview.archive {
         render_archive_preview(frame, ap, size, &title, false);
+    } else if ctx.preview.is_loading {
+        let block = Block::default().borders(Borders::ALL).title(title);
+        let para = Paragraph::new("  Loading...")
+            .style(Style::default().fg(Color::DarkGray))
+            .block(block);
+        frame.render_widget(para, size);
     } else {
         let block = Block::default().borders(Borders::ALL).title(title);
         let para = Paragraph::new("No preview available").block(block);
@@ -202,6 +208,20 @@ fn render_side_preview(
         render_hex_preview(frame, hp, area, &title, preview_focused);
     } else if let Some(ref ap) = ctx.preview.archive {
         render_archive_preview(frame, ap, area, &title, preview_focused);
+    } else if ctx.preview.is_loading {
+        let border_style = if preview_focused {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default()
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(" Preview ")
+            .border_style(border_style);
+        let para = Paragraph::new("  Loading...")
+            .style(Style::default().fg(Color::DarkGray))
+            .block(block);
+        frame.render_widget(para, area);
     } else {
         let border_style = if preview_focused {
             Style::default().fg(Color::Cyan)

--- a/src/render/preview/archive.rs
+++ b/src/render/preview/archive.rs
@@ -39,6 +39,7 @@ impl ArchiveEntry {
 }
 
 /// Archive preview content
+#[derive(Clone)]
 pub struct ArchivePreview {
     /// Archive entries
     pub entries: Vec<ArchiveEntry>,

--- a/src/render/preview/diff.rs
+++ b/src/render/preview/diff.rs
@@ -11,6 +11,7 @@ use ratatui::{
 use super::common::get_border_style;
 
 /// Git diff preview content
+#[derive(Clone)]
 pub struct DiffPreview {
     /// The diff data
     pub diff: crate::git::FileDiff,

--- a/src/render/preview/text.rs
+++ b/src/render/preview/text.rs
@@ -50,6 +50,7 @@ pub struct StyledLine {
 }
 
 /// Text preview content
+#[derive(Clone)]
 pub struct TextPreview {
     pub lines: Vec<String>,
     /// Syntax-highlighted lines (None for plain text)


### PR DESCRIPTION
## Summary
- Text/Diff/Directory/Archive/VideoMeta プレビュー生成をバックグラウンドワーカースレッドに移行し、UIスレッドのブロックを解消
- 既存の `ImageLoader` パターン（mpsc チャンネル + ワーカースレッド）を踏襲した `PreviewWorker` を新規追加
- シリアル番号による last-request-wins キャンセル戦略と LRU キャッシュ（32エントリ）を実装

## Changes
| ファイル | 内容 |
|---------|------|
| `src/app/preview_worker.rs` | **新規** ワーカースレッド、型定義、LRU キャッシュ |
| `src/app/preview.rs` | ワーカー統合、キャッシュ、`poll_preview_result()` |
| `src/app/event_loop.rs` | `poll_image_result` → `poll_preview_result` |
| `src/app/render.rs` | 「Loading...」プレースホルダー表示追加 |
| `src/app/mod.rs` | `mod preview_worker` 追加 |
| `src/render/preview/{text,diff,archive}.rs` | `#[derive(Clone)]` 追加 |

## Design decisions
- **Hex/PDF/Custom は同期のまま**: Hex は 4KB のみで十分高速、PDF は `Picker` が `Send` でない、Custom は外部コマンドの挙動が予測不能
- **VideoMeta のみワーカーで生成**: サムネイルは既存 `ImageLoader` が担当
- **キャッシュヒット時は即座表示**: ワーカーの往復なしで同じファイルに戻ったとき瞬時にプレビュー表示

## Test plan
- [x] `cargo test` — 346 テスト全パス
- [x] `cargo clippy` — 警告ゼロ
- [ ] 手動: 大きなテキストファイル上でカーソルを素早く移動し、UI がブロックされないことを確認
- [ ] 手動: git 変更ファイル・zip/tar.gz・動画ファイルでプレビューが正常表示されることを確認
- [ ] 手動: 「Loading...」表示後にプレビューが表示されることを確認
- [ ] 手動: 同じファイルに戻ったときキャッシュヒットで即座表示されることを確認

Closes #150