### PR TITLE
perf: optimize fuzzy finder with incremental candidate narrowing

### DIFF
--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -19,7 +19,7 @@ use crate::handler::{
     mouse::{handle_mouse_event, ClickDetector, MouseAction, PathBuffer},
 };
 use crate::plugin::{PluginAction, PluginEvent, PluginManager};
-use crate::render::{collect_paths, fuzzy_match, visible_height, FuzzyMatch, Picker};
+use crate::render::{collect_paths, fuzzy_match_incremental, visible_height, FuzzyMatch, FuzzyState, Picker};
 use crate::tree::TreeNavigator;
 use crate::watcher::FileWatcher;
 
@@ -122,6 +122,7 @@ pub fn run_app(
     // Fuzzy finder state
     let mut fuzzy_paths: Vec<PathBuf> = Vec::new();
     let mut fuzzy_results: Vec<FuzzyMatch> = Vec::new();
+    let mut fuzzy_state = FuzzyState::new();
 
     // Lazy initialization: defer Git detection until after the first frame
     // to improve perceived startup time (first frame renders faster)
@@ -355,8 +356,8 @@ pub fn run_app(
                     // Handle fuzzy finder text input
                     if let ViewMode::FuzzyFinder { query, .. } = &state.mode {
                         if let Some((new_buf, _)) = update_input_buffer(key, query, query.len()) {
-                            // Refresh results when query changes
-                            fuzzy_results = fuzzy_match(&new_buf, &fuzzy_paths, &state.root);
+                            // Refresh results when query changes (incremental narrowing)
+                            fuzzy_results = fuzzy_match_incremental(&new_buf, &fuzzy_paths, &state.root, &mut fuzzy_state);
                             state.mode = ViewMode::FuzzyFinder {
                                 query: new_buf,
                                 selected: 0, // Reset selection on query change
@@ -523,7 +524,8 @@ pub fn run_app(
                         } else {
                             collect_paths(&state.root, state.show_hidden)
                         };
-                        fuzzy_results = fuzzy_match("", &fuzzy_paths, &state.root);
+                        fuzzy_state.reset();
+                        fuzzy_results = fuzzy_match_incremental("", &fuzzy_paths, &state.root, &mut fuzzy_state);
                     }
 
                     // Fill in actual path for FuzzyConfirm

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -19,7 +19,9 @@ use crate::handler::{
     mouse::{handle_mouse_event, ClickDetector, MouseAction, PathBuffer},
 };
 use crate::plugin::{PluginAction, PluginEvent, PluginManager};
-use crate::render::{collect_paths, fuzzy_match_incremental, visible_height, FuzzyMatch, FuzzyState, Picker};
+use crate::render::{
+    collect_paths, fuzzy_match_incremental, visible_height, FuzzyMatch, FuzzyState, Picker,
+};
 use crate::tree::TreeNavigator;
 use crate::watcher::FileWatcher;
 
@@ -357,7 +359,12 @@ pub fn run_app(
                     if let ViewMode::FuzzyFinder { query, .. } = &state.mode {
                         if let Some((new_buf, _)) = update_input_buffer(key, query, query.len()) {
                             // Refresh results when query changes (incremental narrowing)
-                            fuzzy_results = fuzzy_match_incremental(&new_buf, &fuzzy_paths, &state.root, &mut fuzzy_state);
+                            fuzzy_results = fuzzy_match_incremental(
+                                &new_buf,
+                                &fuzzy_paths,
+                                &state.root,
+                                &mut fuzzy_state,
+                            );
                             state.mode = ViewMode::FuzzyFinder {
                                 query: new_buf,
                                 selected: 0, // Reset selection on query change
@@ -525,7 +532,12 @@ pub fn run_app(
                             collect_paths(&state.root, state.show_hidden)
                         };
                         fuzzy_state.reset();
-                        fuzzy_results = fuzzy_match_incremental("", &fuzzy_paths, &state.root, &mut fuzzy_state);
+                        fuzzy_results = fuzzy_match_incremental(
+                            "",
+                            &fuzzy_paths,
+                            &state.root,
+                            &mut fuzzy_state,
+                        );
                     }
 
                     // Fill in actual path for FuzzyConfirm

--- a/src/render/fuzzy.rs
+++ b/src/render/fuzzy.rs
@@ -76,8 +76,7 @@ pub fn fuzzy_match_incremental(
             .collect();
     }
 
-    let incremental =
-        !state.prev_query.is_empty() && query.starts_with(&state.prev_query);
+    let incremental = !state.prev_query.is_empty() && query.starts_with(&state.prev_query);
 
     let mut matcher = Matcher::new(nucleo_matcher::Config::DEFAULT);
     let pattern = Pattern::parse(query, CaseMatching::Smart, Normalization::Smart);
@@ -650,10 +649,7 @@ mod tests {
     #[test]
     fn test_backspace_triggers_full_scan() {
         let root = PathBuf::from("/test");
-        let paths = vec![
-            PathBuf::from("/test/foo.rs"),
-            PathBuf::from("/test/bar.rs"),
-        ];
+        let paths = vec![PathBuf::from("/test/foo.rs"), PathBuf::from("/test/bar.rs")];
         let mut state = FuzzyState::new();
 
         // Type "foo" first
@@ -670,10 +666,7 @@ mod tests {
     #[test]
     fn test_incremental_empty_query_resets() {
         let root = PathBuf::from("/test");
-        let paths = vec![
-            PathBuf::from("/test/a.rs"),
-            PathBuf::from("/test/b.rs"),
-        ];
+        let paths = vec![PathBuf::from("/test/a.rs"), PathBuf::from("/test/b.rs")];
         let mut state = FuzzyState::new();
 
         fuzzy_match_incremental("a", &paths, &root, &mut state);

--- a/src/render/fuzzy.rs
+++ b/src/render/fuzzy.rs
@@ -30,6 +30,107 @@ pub struct FuzzyMatch {
     pub indices: Vec<usize>,
 }
 
+/// State for incremental fuzzy matching
+#[derive(Default)]
+pub struct FuzzyState {
+    prev_query: String,
+    matched_indices: Vec<usize>,
+}
+
+impl FuzzyState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn reset(&mut self) {
+        self.prev_query.clear();
+        self.matched_indices.clear();
+    }
+}
+
+/// Perform incremental fuzzy matching, reusing previous results when the query is extended
+pub fn fuzzy_match_incremental(
+    query: &str,
+    paths: &[PathBuf],
+    root: &PathBuf,
+    state: &mut FuzzyState,
+) -> Vec<FuzzyMatch> {
+    if query.is_empty() {
+        state.reset();
+        return paths
+            .iter()
+            .take(MAX_RESULTS)
+            .map(|p| {
+                let display = p
+                    .strip_prefix(root)
+                    .unwrap_or(p)
+                    .to_string_lossy()
+                    .to_string();
+                FuzzyMatch {
+                    path: p.clone(),
+                    display,
+                    score: 0,
+                    indices: vec![],
+                }
+            })
+            .collect();
+    }
+
+    let incremental =
+        !state.prev_query.is_empty() && query.starts_with(&state.prev_query);
+
+    let mut matcher = Matcher::new(nucleo_matcher::Config::DEFAULT);
+    let pattern = Pattern::parse(query, CaseMatching::Smart, Normalization::Smart);
+
+    let mut new_matched_indices = Vec::new();
+
+    let iter: Box<dyn Iterator<Item = (usize, &PathBuf)>> = if incremental {
+        Box::new(
+            state
+                .matched_indices
+                .iter()
+                .filter_map(|&idx| paths.get(idx).map(|p| (idx, p))),
+        )
+    } else {
+        Box::new(paths.iter().enumerate())
+    };
+
+    let mut results: Vec<FuzzyMatch> = iter
+        .filter_map(|(idx, path)| {
+            let display = path
+                .strip_prefix(root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .to_string();
+
+            let mut buf = Vec::new();
+            let haystack = Utf32Str::new(&display, &mut buf);
+
+            let mut indices = Vec::new();
+            let score = pattern.indices(haystack, &mut matcher, &mut indices)?;
+
+            let indices: Vec<usize> = indices.iter().map(|&i| i as usize).collect();
+
+            new_matched_indices.push(idx);
+
+            Some(FuzzyMatch {
+                path: path.clone(),
+                display,
+                score,
+                indices,
+            })
+        })
+        .collect();
+
+    results.sort_by(|a, b| b.score.cmp(&a.score));
+    results.truncate(MAX_RESULTS);
+
+    state.matched_indices = new_matched_indices;
+    state.prev_query = query.to_string();
+
+    results
+}
+
 /// Perform fuzzy matching on a list of paths
 pub fn fuzzy_match(query: &str, paths: &[PathBuf], root: &PathBuf) -> Vec<FuzzyMatch> {
     if query.is_empty() {
@@ -510,5 +611,77 @@ mod tests {
         // Verify constant is reasonable (compile-time check)
         const { assert!(MAX_RESULTS > 0) };
         const { assert!(MAX_RESULTS <= 100) }; // Should not be too large
+    }
+
+    #[test]
+    fn test_fuzzy_state_reset() {
+        let mut state = FuzzyState::new();
+        state.prev_query = "foo".to_string();
+        state.matched_indices = vec![0, 1, 2];
+        state.reset();
+        assert!(state.prev_query.is_empty());
+        assert!(state.matched_indices.is_empty());
+    }
+
+    #[test]
+    fn test_incremental_narrowing() {
+        let root = PathBuf::from("/test");
+        let paths = vec![
+            PathBuf::from("/test/foo.rs"),
+            PathBuf::from("/test/foobar.rs"),
+            PathBuf::from("/test/bar.rs"),
+            PathBuf::from("/test/baz.rs"),
+        ];
+        let mut state = FuzzyState::new();
+
+        // First query: "fo" matches foo.rs and foobar.rs
+        let results = fuzzy_match_incremental("fo", &paths, &root, &mut state);
+        assert!(results.iter().all(|r| r.display.contains("foo")));
+        assert_eq!(state.prev_query, "fo");
+        let prev_matched_count = state.matched_indices.len();
+        assert!(prev_matched_count <= 2); // only foo.rs and foobar.rs
+
+        // Extend query: "foo" should use incremental narrowing (subset of previous)
+        let results2 = fuzzy_match_incremental("foo", &paths, &root, &mut state);
+        assert!(results2.iter().all(|r| r.display.contains("foo")));
+        assert_eq!(state.prev_query, "foo");
+    }
+
+    #[test]
+    fn test_backspace_triggers_full_scan() {
+        let root = PathBuf::from("/test");
+        let paths = vec![
+            PathBuf::from("/test/foo.rs"),
+            PathBuf::from("/test/bar.rs"),
+        ];
+        let mut state = FuzzyState::new();
+
+        // Type "foo" first
+        fuzzy_match_incremental("foo", &paths, &root, &mut state);
+        assert_eq!(state.prev_query, "foo");
+
+        // Backspace to "f" - not a prefix extension, should do full scan
+        let results = fuzzy_match_incremental("f", &paths, &root, &mut state);
+        assert_eq!(state.prev_query, "f");
+        // "f" should match "foo.rs" at minimum
+        assert!(results.iter().any(|r| r.display.contains("foo")));
+    }
+
+    #[test]
+    fn test_incremental_empty_query_resets() {
+        let root = PathBuf::from("/test");
+        let paths = vec![
+            PathBuf::from("/test/a.rs"),
+            PathBuf::from("/test/b.rs"),
+        ];
+        let mut state = FuzzyState::new();
+
+        fuzzy_match_incremental("a", &paths, &root, &mut state);
+        assert!(!state.prev_query.is_empty());
+
+        let results = fuzzy_match_incremental("", &paths, &root, &mut state);
+        assert!(state.prev_query.is_empty());
+        assert!(state.matched_indices.is_empty());
+        assert_eq!(results.len(), 2);
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -13,7 +13,10 @@ pub mod theme;
 pub mod tree;
 
 pub use bulk_rename::render_bulk_rename_dialog;
-pub use fuzzy::{collect_paths, fuzzy_match, fuzzy_match_incremental, render_fuzzy_finder, FuzzyMatch, FuzzyState};
+pub use fuzzy::{
+    collect_paths, fuzzy_match, fuzzy_match_incremental, render_fuzzy_finder, FuzzyMatch,
+    FuzzyState,
+};
 pub use history::render_ai_history_popup;
 pub use icons::get_icon;
 pub use layout::{LayoutEngine, StatusLayout, TreeColumns};

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -13,7 +13,7 @@ pub mod theme;
 pub mod tree;
 
 pub use bulk_rename::render_bulk_rename_dialog;
-pub use fuzzy::{collect_paths, fuzzy_match, render_fuzzy_finder, FuzzyMatch};
+pub use fuzzy::{collect_paths, fuzzy_match, fuzzy_match_incremental, render_fuzzy_finder, FuzzyMatch, FuzzyState};
 pub use history::render_ai_history_popup;
 pub use icons::get_icon;
 pub use layout::{LayoutEngine, StatusLayout, TreeColumns};


### PR DESCRIPTION
## Summary

- Fuzzy finder のクエリが前回のプレフィックス拡張（例: "fo" → "foo"）の場合、前回マッチした候補のみ再スキャンする増分絞り込みを実装
- バックスペースやプレフィックス変更時はフルスキャンにフォールバック
- `FuzzyState` 構造体で前回クエリとマッチ済みインデックスを保持

## Test plan

- [x] `cargo test` — 全テストパス（新規4テスト含む27件）
- [x] `cargo clippy` — 警告なし
- [ ] 大量ファイルのディレクトリで Ctrl+P → 文字を素早く入力し、ラグなく結果が更新されることを確認
- [ ] バックスペースで文字を削除した後も正しい結果が表示されることを確認
- [ ] 空クエリに戻したとき全候補の先頭が表示されることを確認

Closes #151