### PR TITLE
release: v2.4.0 - performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-02-28
+
+### Added
+
+- Speed-oriented `release-fast` Cargo profile for maximum runtime performance
+
+### Changed
+
+- **Dirty-frame rendering**: skip redrawing on idle frames, reducing CPU usage when nothing changes
+- **Cached visible entries**: flatten and cache the visible tree with a dirty flag, avoiding repeated traversal
+- **Event-driven watcher sync**: sync file watcher with expanded directories only when the set changes
+- **Cached status-bar metadata**: cache file size / mod-time to eliminate repeated `stat()` calls
+- **Precomputed sort keys**: compute sort keys once on tree load instead of on every comparison
+- **Async preview worker**: move heavy preview generation (syntax highlight, hex dump, etc.) off the UI thread
+- **Incremental fuzzy narrowing**: when the query extends the previous prefix, re-scan only prior matches instead of all candidates
+- Updated dependencies (petgraph 0.8.3, toml 1.0.1, rust-minor-patch group, Cargo.lock refresh)
+
 ## [2.3.2] - 2026-02-12
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.3.2"
+version = "2.4.0"
 edition = "2021"
 rust-version = "1.90.0"  # MSRV - Minimum Supported Rust Version
 description = "A minimal file tree UI for terminal emulators"


### PR DESCRIPTION
## Summary

- Cargo.toml バージョンを 2.3.2 → 2.4.0 に更新
- CHANGELOG.md に v2.4.0 エントリを追加

### v2.3.2 以降の主な変更

**パフォーマンス改善:**
- Dirty-frame rendering（アイドル時の再描画スキップ）
- Visible entries キャッシュ（ツリー平坦化の重複排除）
- Event-driven watcher sync（ファイル監視の差分同期）
- Status-bar metadata キャッシュ（stat() 呼び出し削減）
- Sort key プリコンピュート（比較時の metadata() 排除）
- Async preview worker（プレビュー生成の非同期化）
- Incremental fuzzy narrowing（Fuzzy Finder の増分絞り込み）

**新機能:**
- `release-fast` Cargo プロファイル追加

**依存関係:**
- petgraph, toml, その他マイナーパッチ更新

## Verification

- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (346 passed)