### PR TITLE
fix(clippy): resolve new lints from Rust 1.95

### DIFF
--- a/src/handler/action/display.rs
+++ b/src/handler/action/display.rs
@@ -447,18 +447,14 @@ pub fn handle_pdf_navigation(
     };
 
     match action {
-        KeyAction::PdfPrevPage => {
-            if pdf.current_page > 1 {
-                if let Err(e) = pdf.prev_page(picker) {
-                    state.set_message(format!("Failed: prev page - {}", e));
-                }
+        KeyAction::PdfPrevPage if pdf.current_page > 1 => {
+            if let Err(e) = pdf.prev_page(picker) {
+                state.set_message(format!("Failed: prev page - {}", e));
             }
         }
-        KeyAction::PdfNextPage => {
-            if pdf.current_page < pdf.total_pages {
-                if let Err(e) = pdf.next_page(picker) {
-                    state.set_message(format!("Failed: next page - {}", e));
-                }
+        KeyAction::PdfNextPage if pdf.current_page < pdf.total_pages => {
+            if let Err(e) = pdf.next_page(picker) {
+                state.set_message(format!("Failed: next page - {}", e));
             }
         }
         _ => {}

--- a/src/handler/action/navigation.rs
+++ b/src/handler/action/navigation.rs
@@ -21,10 +21,8 @@ pub fn handle(action: KeyAction, state: &mut AppState, entries: &[EntrySnapshot]
         KeyAction::MoveUp => {
             state.focus_index = state.focus_index.saturating_sub(1);
         }
-        KeyAction::MoveDown => {
-            if state.focus_index < entries.len().saturating_sub(1) {
-                state.focus_index += 1;
-            }
+        KeyAction::MoveDown if state.focus_index < entries.len().saturating_sub(1) => {
+            state.focus_index += 1;
         }
         KeyAction::MoveToTop => {
             state.focus_index = 0;

--- a/src/render/fuzzy.rs
+++ b/src/render/fuzzy.rs
@@ -121,7 +121,7 @@ pub fn fuzzy_match_incremental(
         })
         .collect();
 
-    results.sort_by(|a, b| b.score.cmp(&a.score));
+    results.sort_by_key(|b| std::cmp::Reverse(b.score));
     results.truncate(MAX_RESULTS);
 
     state.matched_indices = new_matched_indices;
@@ -184,7 +184,7 @@ pub fn fuzzy_match(query: &str, paths: &[PathBuf], root: &PathBuf) -> Vec<FuzzyM
         .collect();
 
     // Sort by score descending
-    results.sort_by(|a, b| b.score.cmp(&a.score));
+    results.sort_by_key(|b| std::cmp::Reverse(b.score));
 
     // Limit results
     results.truncate(MAX_RESULTS);


### PR DESCRIPTION
## Summary

Rust stable bumped to 1.95 since the last successful CI run, introducing stricter clippy lints that break `-D warnings`:

- `collapsible_match` — `src/handler/action/display.rs:451,458` and `src/handler/action/navigation.rs:25`
- `unnecessary_sort_by` — `src/render/fuzzy.rs:124,187`

This is blocking all open Dependabot PRs (#172, #173, #174) because their rebased CI runs now pick up these failures.

## Changes

- Use match guards to collapse trailing `if` inside match arms
- Replace `sort_by(|a, b| b.score.cmp(&a.score))` with `sort_by_key(|b| std::cmp::Reverse(b.score))`

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes locally
- [x] `cargo fmt --check` passes
- [ ] CI green on PR