### PR TITLE
chore(release): prepare 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.0] - 2026-04-19
 
 ### Added
 
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `fv --mcp-server` in a separate process, the interactive `fv` TUI now shows
   the AI's tool calls in real time. The most recent event appears in the
   status bar as `[AI] claude: read_file src/auth.rs`, and an optional
-  follow-mode auto-focuses the tree on the file the AI just touched.
+  follow-mode auto-focuses the tree on the file the AI just touched. (#179)
   - `Alt+A`: toggle follow-mode (opt-in; off by default so the UI never
     interrupts text input unexpectedly).
   - `Alt+L`: open the live activity log popup (up to 100 events, `j/k`
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - File-based protocol: the MCP server writes events to
     `~/.cache/fileview/sessions/<pid>/activity.jsonl`; the interactive TUI
     watches that file via `notify`. The log is owner-only (`0600`) on unix.
+  - Batch tools (`read_files`, `estimate_tokens`) emit one event per path so
+    every file the AI touches is visible in the UI.
 
 ## [2.4.1] - 2026-04-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.4.1"
+version = "2.5.0"
 edition = "2021"
 rust-version = "1.90.0"  # MSRV - Minimum Supported Rust Version
 description = "A fast, keyboard-driven TUI file browser with previews and git"


### PR DESCRIPTION
## Summary

Minor bump for the live AI activity reflection feature landed in #179.

- `2.4.1` → `2.5.0`
- User-facing additions: status-bar `[AI]` indicator, `Alt+A` follow-mode toggle, `Alt+L` activity log popup, `--follow-ai` CLI flag
- File-based IPC so `fv --mcp-server` and interactive `fv` can share AI activity in near real-time
- No breaking changes

See `CHANGELOG.md` for the full entry.

## Post-merge

1. Merge this PR to `main`
2. Tag `v2.5.0` and push — `release.yml` builds binaries + creates GitHub Release automatically
3. `cargo publish --no-verify` from local (CI publish job still fails because `CARGO_REGISTRY_TOKEN` secret is empty; that was the same story for v2.4.1)

## Test plan

- [ ] CI green (lint / test ×3 / msrv / ci-success)
- [ ] `cargo build --release` succeeds locally (verified)
- [ ] 975 tests pass (verified)
- [ ] `scripts/demo_ai_activity.sh` works against `./target/release/fv --follow-ai .`