### PR TITLE
chore(ci): drop crates.io publish job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,19 +121,6 @@ jobs:
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           generate_release_notes: true
 
-  # Publish to crates.io
-  publish:
-    name: Publish to crates.io
-    needs: release
-    runs-on: ubuntu-latest
-    # Only publish stable releases (not alpha/beta/rc)
-    if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --no-verify
+# Note: crates.io publishing is done manually (`cargo publish --no-verify`) so
+# the release timing can be controlled without keeping a `CARGO_REGISTRY_TOKEN`
+# secret in GitHub Actions. See docs/RELEASE_POLICY.md.

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -39,6 +39,19 @@ Stable 昇格前に以下を満たすこと:
 2. pre-release は suffix を含める（例: `v2.4.0-alpha.1`）
 3. superseded な版（例: 公開直後に置き換え）を `CHANGELOG.md` に明記
 
+## Publishing to crates.io
+
+crates.io への公開は**手動**で行う（CI では行わない）。
+
+```bash
+cargo publish --no-verify
+```
+
+GitHub Actions の `release.yml` はタグ push でバイナリビルドと GitHub
+Release 作成のみ自動化する。crates.io publish を CI から外してあるのは、
+公開タイミングをメンテナ側で制御できるようにするため、および
+`CARGO_REGISTRY_TOKEN` を Actions secret として常時持ち込まないため。
+
 ## Communication Rules
 
 毎リリースで以下を更新:

--- a/docs/RELEASE_POLICY_ja.md
+++ b/docs/RELEASE_POLICY_ja.md
@@ -39,6 +39,19 @@ Stable 昇格前に以下を満たすこと:
 2. pre-release は suffix を含める（例: `v2.4.0-alpha.1`）
 3. superseded な版（例: 公開直後に置き換え）を `CHANGELOG.md` に明記
 
+## crates.io への公開
+
+crates.io への公開は**手動**で行う（CI からは行わない）。
+
+```bash
+cargo publish --no-verify
+```
+
+GitHub Actions の `release.yml` はタグ push 時にバイナリビルドと
+GitHub Release 作成のみを自動化する。crates.io publish を CI 経由にしないのは、
+公開タイミングをメンテナ側で制御できるようにするため、および
+`CARGO_REGISTRY_TOKEN` を Actions secret として常時持ち込まないため。
+
 ## コミュニケーションルール
 
 毎リリースで以下を更新:


### PR DESCRIPTION
## Summary

The `publish` job in `release.yml` has failed on every tag push (v2.4.1, v2.5.0) because `CARGO_REGISTRY_TOKEN` is intentionally unset — the maintainer prefers to run `cargo publish --no-verify` manually.

- Remove the failing job.
- Document the manual publish step in `docs/RELEASE_POLICY.md` (+ Japanese mirror).
- Binary builds and GitHub Release creation stay automated.

## Result after merge

- `release.yml` flow on tag push: matrix binary build × 4 targets → create GitHub Release with artifacts + checksums. That's it.
- crates.io publish is a maintainer CLI step: `cargo publish --no-verify`.

## Test plan

- [ ] CI green on this PR
- [ ] No remaining `CARGO_REGISTRY_TOKEN` references in workflows