### PR TITLE
docs(claude-code): add live AI activity reflection setup guide

### DIFF
--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -84,9 +84,9 @@ fv init claude --path ~/.claude.json
 ## Live AI Activity Reflection (v2.5.0+)
 
 When an AI agent calls `fv --mcp-server` in one process and you are running
-the interactive `fv` in another, the interactive TUI surfaces the AI's tool
-calls in real time — a status-bar indicator and an optional follow-mode that
-auto-focuses the tree on the file the AI just touched.
+the interactive `fv` in another, the interactive TUI shows the AI's tool
+calls in real time. There is a status-bar indicator, and an optional
+follow-mode that auto-focuses the tree on the file the AI just touched.
 
 ### Setup
 
@@ -133,14 +133,14 @@ auto-focuses the tree on the file the AI just touched.
 | `Alt+A` | Toggle follow-mode (auto-focus on the AI's most recent file) |
 | `Alt+L` | Open the live activity log popup (`j`/`k` to navigate, `Enter` to jump, `Esc`/`q` to close) |
 
-Follow-mode is suppressed automatically while you are typing in any input
-mode (search, filter, rename, bulk rename, fuzzy finder, confirmation), so it
-never eats a keystroke you intended to land somewhere else.
+Follow-mode is suppressed automatically while you are in any input mode
+(search, filter, rename, bulk rename, fuzzy finder, confirmation), so it
+will not interrupt a keystroke you meant for another control.
 
 ### How the two processes talk
 
 The MCP server and the interactive TUI are independent OS processes. They
-rendezvous through a file-based protocol in your user cache directory:
+share state through a file-based protocol in your user cache directory:
 
 - The interactive process registers a directory at
   `~/.cache/fileview/sessions/<pid>/` containing a `session.json`
@@ -155,12 +155,13 @@ rendezvous through a file-based protocol in your user cache directory:
 
 - **Nothing shows up in the status bar.** Confirm the interactive `fv` is
   rooted at the same directory you passed to `fv --mcp-server`, or one of
-  its ancestors. Events are scoped by path to keep unrelated projects
-  from cross-talking.
+  its ancestors. Events are scoped by path so that unrelated projects do
+  not see each other's activity.
 - **`--follow-ai` printed "activity registry unavailable".** The cache
-  directory could not be created (e.g. read-only home). Live reflection
-  will still attempt events; only follow-mode is disabled.
+  directory could not be created (for example a read-only home). Live
+  reflection will still try to deliver events; only follow-mode is
+  disabled.
 - **Stale session directories.** The MCP server prunes sessions whose PID
   is no longer alive on the next emit. You can also remove
-  `~/.cache/fileview/sessions/*` by hand — the interactive fileview will
+  `~/.cache/fileview/sessions/*` by hand. The interactive fileview will
   recreate its own entry on startup.

--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -80,3 +80,87 @@ fv init claude --path ~/.claude.json
 **Context**: `get_smart_context`, `estimate_tokens`, `compress_context`
 
 **Project**: `run_build`, `run_test`, `run_lint`, `get_project_stats`
+
+## Live AI Activity Reflection (v2.5.0+)
+
+When an AI agent calls `fv --mcp-server` in one process and you are running
+the interactive `fv` in another, the interactive TUI surfaces the AI's tool
+calls in real time — a status-bar indicator and an optional follow-mode that
+auto-focuses the tree on the file the AI just touched.
+
+### Setup
+
+1. Make sure you are on `fileview >= 2.5.0` (`fv --version`).
+2. Register `fv --mcp-server` with Claude Code. The easiest way is
+   `fv init claude`, which edits `~/.claude.json` in place. The resulting
+   entry looks like:
+
+   ```json
+   {
+     "mcpServers": {
+       "fileview": {
+         "command": "fv",
+         "args": ["--mcp-server", "/absolute/path/to/your/project"]
+       }
+     }
+   }
+   ```
+
+3. In a separate terminal (attached to the same machine, same user), open the
+   interactive fileview on the project root Claude Code was registered with:
+
+   ```bash
+   cd /absolute/path/to/your/project
+   fv --follow-ai .
+   ```
+
+   Without `--follow-ai`, the TUI still shows the AI's activity in the status
+   bar but does not auto-move focus.
+
+4. When Claude Code runs a tool call via the MCP server (for example while
+   reading `src/auth.rs`), the interactive fileview shows:
+
+   ```
+   [AI*] claude: read_file src/auth.rs
+   ```
+
+   and, with follow-mode on, reveals and focuses that path in the tree.
+
+### Keybindings
+
+| Key | Action |
+|-----|--------|
+| `Alt+A` | Toggle follow-mode (auto-focus on the AI's most recent file) |
+| `Alt+L` | Open the live activity log popup (`j`/`k` to navigate, `Enter` to jump, `Esc`/`q` to close) |
+
+Follow-mode is suppressed automatically while you are typing in any input
+mode (search, filter, rename, bulk rename, fuzzy finder, confirmation), so it
+never eats a keystroke you intended to land somewhere else.
+
+### How the two processes talk
+
+The MCP server and the interactive TUI are independent OS processes. They
+rendezvous through a file-based protocol in your user cache directory:
+
+- The interactive process registers a directory at
+  `~/.cache/fileview/sessions/<pid>/` containing a `session.json`
+  (pid + root + started_at) and an append-only `activity.jsonl`
+  (permissions `0600` on unix).
+- On every tool call, `fv --mcp-server` appends a JSONL line to each alive
+  session whose root is an ancestor of the path being acted on.
+- The interactive process watches the log via the `notify` crate and
+  drains events per frame.
+
+### Troubleshooting
+
+- **Nothing shows up in the status bar.** Confirm the interactive `fv` is
+  rooted at the same directory you passed to `fv --mcp-server`, or one of
+  its ancestors. Events are scoped by path to keep unrelated projects
+  from cross-talking.
+- **`--follow-ai` printed "activity registry unavailable".** The cache
+  directory could not be created (e.g. read-only home). Live reflection
+  will still attempt events; only follow-mode is disabled.
+- **Stale session directories.** The MCP server prunes sessions whose PID
+  is no longer alive on the next emit. You can also remove
+  `~/.cache/fileview/sessions/*` by hand — the interactive fileview will
+  recreate its own entry on startup.

--- a/docs/CLAUDE_CODE_ja.md
+++ b/docs/CLAUDE_CODE_ja.md
@@ -68,3 +68,84 @@ fv init claude --path ~/.claude.json
 ```
 
 詳細仕様は英語版も参照してください: `docs/CLAUDE_CODE.md`
+
+## ライブAIアクティビティ反映（v2.5.0+）
+
+`fv --mcp-server` を別プロセスで動かしている AI エージェントからの
+tool call を、対話型 `fv` がリアルタイムで UI に反映します。ステータスバーに
+直近の操作を表示し、follow-mode を有効にすれば AI が読んだファイルに
+自動でフォーカスが移動します。
+
+### セットアップ
+
+1. `fileview >= 2.5.0` であることを確認（`fv --version`）
+2. Claude Code に `fv --mcp-server` を登録。`fv init claude` が簡単で、
+   `~/.claude.json` に以下のようなエントリを追加します:
+
+   ```json
+   {
+     "mcpServers": {
+       "fileview": {
+         "command": "fv",
+         "args": ["--mcp-server", "/absolute/path/to/your/project"]
+       }
+     }
+   }
+   ```
+
+3. 別ターミナル（同じマシン、同じユーザー）で、Claude Code に登録した
+   プロジェクトルートと同じ場所で対話型 fv を起動:
+
+   ```bash
+   cd /absolute/path/to/your/project
+   fv --follow-ai .
+   ```
+
+   `--follow-ai` を付けない場合、ステータスバーには表示されますが
+   自動フォーカスは行われません。
+
+4. Claude Code が MCP 経由で `read_file src/auth.rs` などを呼ぶと、
+   対話型 fileview に以下のように表示されます:
+
+   ```
+   [AI*] claude: read_file src/auth.rs
+   ```
+
+   follow-mode 有効時は tree がそのパスに自動でジャンプします。
+
+### キーバインド
+
+| キー | 動作 |
+|---|---|
+| `Alt+A` | follow-mode 切り替え（AI の直近ファイルに自動フォーカス） |
+| `Alt+L` | ライブ活動ログ popup を開く（`j`/`k` 移動、`Enter` でジャンプ、`Esc`/`q` で閉じる） |
+
+検索・フィルタ・リネーム・bulk rename・fuzzy finder・確認ダイアログ等の
+入力モード中は follow-mode が自動的に抑止されるので、
+意図したキー入力が勝手に消えたりフォーカスが奪われたりはしません。
+
+### 2プロセスの連携方法
+
+MCP サーバーと対話型 TUI は別 OS プロセスとして動作し、ユーザーのキャッシュ
+ディレクトリ経由で連携します:
+
+- 対話型プロセスは `~/.cache/fileview/sessions/<pid>/` を作り、
+  `session.json`（pid + ルート + 起動時刻）と追記専用の
+  `activity.jsonl`（unix では権限 `0600`）を置きます
+- `fv --mcp-server` は tool call のたびに、対象パスを祖先に持つ生存中の
+  全セッションの `activity.jsonl` に JSONL 1行を追記します
+- 対話型プロセスは `notify` crate でそのファイルを監視し、フレームごとに
+  新しいイベントを取り込みます
+
+### トラブルシューティング
+
+- **ステータスバーに何も出ない**: 対話型 `fv` のルートが、`fv --mcp-server`
+  に渡したディレクトリと同じか、その祖先になっているか確認してください。
+  無関係なプロジェクト間で混線しないようパスでスコープを絞っています
+- **`--follow-ai` 起動時に "activity registry unavailable" が出た**:
+  キャッシュディレクトリを作成できない状況（読み取り専用ホームなど）で発生します。
+  イベント配信自体は試みますが、follow-mode は無効化されます
+- **古いセッションディレクトリが残っている**: MCP サーバーは次の emit 時に
+  PID が生存していないセッションを掃除します。気になる場合は
+  `~/.cache/fileview/sessions/*` を手動で削除しても問題ありません。
+  対話型 fileview は起動時に自分の分を作り直します


### PR DESCRIPTION
## Summary

Follow-up to PR #179 / v2.5.0. The new live AI activity reflection feature was not yet documented in the Claude Code integration guide, so anyone arriving from README → CLAUDE_CODE.md could not find the setup steps.

Add an end-to-end section to both `docs/CLAUDE_CODE.md` and `docs/CLAUDE_CODE_ja.md` covering:

- Setup: `fv init claude` or manual `~/.claude.json` entry, plus launching a matching interactive fileview with `--follow-ai`
- What the status bar indicator looks like in practice (`[AI*] claude: read_file src/auth.rs`)
- `Alt+A` / `Alt+L` keybindings and the input-mode suppression guard
- A short architecture note on the cache-dir file-based IPC (activity.jsonl permissions, notify-based watching)
- Troubleshooting for the most likely confusions (paths outside the session root, registry unavailable, stale session dirs)

Docs-only, no code change.

## Test plan

- [ ] CI green (lint passes `cargo doc --no-deps` against the repo)
- [ ] Skim the rendered Markdown on GitHub for table / code-block correctness