### PR TITLE
docs(readme): drop marketing phrasing, shorten AI activity bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MSRV](https://img.shields.io/badge/MSRV-1.90-blue.svg)](https://www.rust-lang.org)
 
-> Zero-config terminal file browser with image preview, built in Rust.
+> Terminal file browser with image preview, written in Rust.
 
 English | [日本語](README_ja.md)
 
@@ -16,7 +16,7 @@ English | [日本語](README_ja.md)
   <img src="assets/demo.gif" alt="FileView Demo" width="80%">
 </p>
 
-I wanted a lightweight file manager like yazi that I could use day-to-day in the terminal and also connect to Claude Code — without spending time on config files.
+Wanted a yazi-like file manager for day-to-day terminal use that also talks to Claude Code. So I wrote this.
 
 ## Features
 
@@ -24,9 +24,7 @@ I wanted a lightweight file manager like yazi that I could use day-to-day in the
 - 2.2ms startup, ~8MB memory ([benchmarks](docs/BENCHMARKS.md))
 - Git status, syntax highlighting, PDF preview, fuzzy finder
 - Vim keybindings, mouse support, Lua plugins
-- Live AI activity reflection: when an AI agent drives `fv --mcp-server`,
-  the interactive TUI surfaces its file activity in the status bar and
-  optionally follows along (see [docs/CLAUDE_CODE.md](docs/CLAUDE_CODE.md))
+- Live reflection of `fv --mcp-server` activity in the TUI ([details](docs/CLAUDE_CODE.md))
 
 ## Quick Start
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MSRV](https://img.shields.io/badge/MSRV-1.90-blue.svg)](https://www.rust-lang.org)
 
-> 設定不要のターミナルファイルブラウザ。画像プレビュー自動検出、Rust製。
+> ターミナルで動くファイルブラウザ。画像プレビュー、Rust製。
 
 [English](README.md) | 日本語
 
@@ -16,7 +16,7 @@
   <img src="assets/demo.gif" alt="FileView デモ" width="80%">
 </p>
 
-yaziのような軽量ファイルマネージャーで、普段使いしながらClaude Codeとも連携できるものが欲しかった。設定ファイルに時間をかけたくなかった。
+yaziのような軽量ファイラを普段使いしたくて、ついでに Claude Code とも繋げられるようにしたかったので書きました。
 
 ## 特徴
 
@@ -24,10 +24,7 @@ yaziのような軽量ファイルマネージャーで、普段使いしなが�
 - 起動 2.2ms、メモリ約 8MB（[ベンチマーク](docs/BENCHMARKS.md)）
 - Git連携、シンタックスハイライト、PDFプレビュー、ファジーファインダー
 - Vimキーバインド、マウス対応、Luaプラグイン
-- ライブAIアクティビティ反映: AIエージェントが `fv --mcp-server` を呼ぶと、
-  対話型TUIが実時間でそのファイル操作をステータスバーに表示し、
-  追従モードでは該当ファイルに自動フォーカスする
-  （[docs/CLAUDE_CODE_ja.md](docs/CLAUDE_CODE_ja.md) 参照）
+- `fv --mcp-server` の活動を対話型TUIにリアルタイム反映（[詳細](docs/CLAUDE_CODE_ja.md)）
 
 ## クイックスタート
 


### PR DESCRIPTION
## Summary

Make the README read more like a README a human would write, not a landing page.

Three small edits only (`README.md` and `README_ja.md`):

1. **Tagline**: remove \"Zero-config\" / \"設定不要\". This was already flagged during the earlier docs fact-check pass (`BENCHMARKS.md` had \"Configuration file: No\" until we corrected it) — fileview does support an optional config file.
   ```diff
   - Zero-config terminal file browser with image preview, built in Rust.
   + Terminal file browser with image preview, written in Rust.
   ```
2. **Motivation line**: drop em-dash, trim English wording, consolidate the JA two-sentence form into one natural sentence.
3. **Live AI activity bullet**: shorten from 3-4 wrapped lines to a single line, at the same weight as the surrounding bullets. Detail lives in `docs/CLAUDE_CODE.md`.

Docs-only, no feature change. Structure and section list untouched.

## Test plan

- [ ] CI green
- [ ] Render the README on GitHub, confirm the shape still scans well