### PR TITLE
docs(release): Add release notes format template

### DIFF
--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -71,3 +71,71 @@ Release 作成のみ自動化する。crates.io publish を CI から外して�
 - 収束後: `2.4.0-rc.1`
 - 安定化完了: `2.4.0`（推奨版）
 - 緊急修正: `2.4.1`
+
+## Release Notes Format
+
+GitHub Releases ページの本文は以下のテンプレで統一する。`CHANGELOG.md`
+の "Keep a Changelog" 形式と整合するセクション分けで、過去の小刻みリリー
+スで生じた言語・見出し・密度のばらつきを抑える。
+
+### Template
+
+```markdown
+# vX.Y.Z[ - Optional Subtitle]
+
+One or two sentence English summary describing the release theme.
+
+## Highlights
+
+- Headline feature one
+- Headline feature two
+
+## Added
+
+- New CLI flag `--foo` for X (#PR)
+- New keybinding `Alt+B` for Y (#PR)
+
+## Changed
+
+- Behavior of Z now does W (was V) (#PR)
+
+## Fixed
+
+- Bug where A caused B (#PR)
+
+## Notes
+
+Breaking changes, migration steps, or compatibility notes. Omit when
+the section would be empty.
+
+---
+
+**Full Changelog**: https://github.com/Hiro-Chiba/fileview/compare/PREV...vX.Y.Z
+```
+
+### Rules
+
+1. **Language**: English only. The TUI and CLI are English first; release
+   notes follow the same convention. Japanese narrative belongs in
+   `README_ja.md` and `CHANGELOG_ja.md`, not in GitHub Releases.
+2. **Title**: `vX.Y.Z` is required. An optional subtitle separated by
+   ` - ` is allowed for milestone releases (e.g. `v1.24.0 - Claude Code
+   Integration`).
+3. **Heading levels**: The release body starts at h2 (`##`). Do not use
+   `# FileView vX.Y.Z` as a body heading; the `vX.Y.Z` title field
+   already plays that role on the Releases page.
+4. **Section order**: Highlights, Added, Changed, Fixed, Notes. Omit any
+   section that would be empty rather than printing a placeholder.
+5. **No emojis**: Avoid decorative emojis throughout the body. The
+   README also drops marketing phrasing, and Releases follow that tone.
+6. **Pull request references**: Append `(#NNN)` to each bullet when a
+   pull request is the source of the change.
+7. **Full Changelog footer**: End with the GitHub auto-generated compare
+   link so readers can drill into commit-level diffs.
+
+### Why not rely on auto-generated notes alone?
+
+GitHub の "Generate release notes" ボタンは PR タイトル一覧を出すだけ
+で、ユーザ目線の "何が変わったか" がぼやける。Highlights を 2〜3 行手で
+書いてからセクションを並べることで、Releases ページを開いた瞬間に価値が
+伝わるリリースノートにする。

--- a/docs/RELEASE_POLICY_ja.md
+++ b/docs/RELEASE_POLICY_ja.md
@@ -71,3 +71,69 @@ GitHub Release 作成のみを自動化する。crates.io publish を CI 経由�
 - 収束後: `2.4.0-rc.1`
 - 安定化完了: `2.4.0`（推奨版）
 - 緊急修正: `2.4.1`
+
+## リリースノート形式
+
+GitHub Releases の本文は次のテンプレで統一する。`CHANGELOG.md` の
+"Keep a Changelog" 形式と整合させ、過去の小刻みリリースで生じていた
+言語・見出し・密度のばらつきを抑える。
+
+### テンプレート
+
+```markdown
+# vX.Y.Z[ - Optional Subtitle]
+
+One or two sentence English summary describing the release theme.
+
+## Highlights
+
+- Headline feature one
+- Headline feature two
+
+## Added
+
+- New CLI flag `--foo` for X (#PR)
+- New keybinding `Alt+B` for Y (#PR)
+
+## Changed
+
+- Behavior of Z now does W (was V) (#PR)
+
+## Fixed
+
+- Bug where A caused B (#PR)
+
+## Notes
+
+Breaking changes, migration steps, or compatibility notes. Omit when
+the section would be empty.
+
+---
+
+**Full Changelog**: https://github.com/Hiro-Chiba/fileview/compare/PREV...vX.Y.Z
+```
+
+### ルール
+
+1. **言語**: 英語のみ。TUI/CLI が英語ベースなので Releases も合わせる。
+   日本語の記述は `README_ja.md` や `CHANGELOG_ja.md` に集約し、
+   GitHub Releases には混在させない。
+2. **タイトル**: `vX.Y.Z` を必須とする。節目リリースには ` - ` 区切り
+   でサブタイトルを付けて良い（例: `v1.24.0 - Claude Code Integration`）。
+3. **見出しレベル**: 本文は h2 (`##`) から始める。`# FileView vX.Y.Z`
+   のような h1 を本文先頭には使わない（タイトルフィールドが同じ役割を
+   果たすため重複になる）。
+4. **セクション順序**: Highlights → Added → Changed → Fixed → Notes。
+   空のセクションはプレースホルダを残さず省略する。
+5. **絵文字なし**: 装飾目的の絵文字は使わない。README も marketing 表現
+   を抑える方針なので、Releases もそれに揃える。
+6. **PR 参照**: 各 bullet の末尾に `(#NNN)` を付ける（PR が出元の場合）。
+7. **Full Changelog**: 末尾に GitHub 自動生成の compare リンクを置き、
+   commit レベルで深掘りできるようにする。
+
+### auto-generate ボタンだけに頼らない理由
+
+GitHub の "Generate release notes" は PR タイトル一覧を吐くだけで、
+ユーザ目線の "何が変わったか" がぼやける。Highlights を 2〜3 行手書きし
+てからセクションを並べることで、Releases ページを開いた瞬間に価値が
+伝わるリリースノートになる。


### PR DESCRIPTION
## Summary

Adds a unified template and rule set for GitHub Releases body to stop
the drift in language, heading levels, section names, and emoji usage
that has accumulated across the prior 60 releases. Pairs with the
release cleanup completed earlier today (60 releases reduced to 15
milestone releases on the Releases page).

The template mirrors the Keep a Changelog sections already used in
`CHANGELOG.md`.

## Rules established

- English only in release bodies (Japanese narrative stays in
  `README_ja.md` / `CHANGELOG_ja.md`).
- Body starts at h2 (`##`); no duplicate `# FileView vX.Y.Z` heading.
- Fixed section order: Highlights, Added, Changed, Fixed, Notes.
  Empty sections are omitted rather than left as placeholders.
- No decorative emojis.
- Per-bullet PR references `(#NNN)` where applicable.
- Trailing `Full Changelog` compare link for commit-level drill-down.

## Out of scope

Rewriting the bodies of the 15 surviving releases to match the new
template. That will happen as a follow-up directly through
`gh release edit` since release bodies are stored on GitHub, not in
the repo.

## Test plan

- [x] Both `RELEASE_POLICY.md` and `RELEASE_POLICY_ja.md` updated in
      lockstep (134 lines added across the two files).
- [x] Template renders correctly in plain text preview.