### PR TITLE
feat(integrate): Add context budget bar

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 
 use super::config_file::{CommandsConfig, ConfigFile, PreviewConfig};
 use crate::integrate::{
-    exit_code, AiIgnoreAgent, Callback, ContextAgent, ContextPackFormat, ContextPackOptions,
-    ContextPackPreset, OutputFormat,
+    exit_code, AiIgnoreAgent, BudgetModel, Callback, ContextAgent, ContextPackFormat,
+    ContextPackOptions, ContextPackPreset, OutputFormat,
 };
 
 /// Session action (save, restore, clear)
@@ -126,6 +126,9 @@ pub struct Config {
     pub resume_ai_session: Option<String>,
     /// Start with AI activity follow-mode enabled (auto-focus on AI's last file)
     pub follow_ai: bool,
+    /// Default model for the context budget bar, sourced from
+    /// `[budget].default_model` in config.toml. None means use built-in default.
+    pub budget_default_model: Option<BudgetModel>,
 }
 
 impl Config {
@@ -539,6 +542,11 @@ impl Config {
             init_ai_write,
             resume_ai_session,
             follow_ai,
+            budget_default_model: if config_file.budget.default_model.is_empty() {
+                None
+            } else {
+                config_file.budget.default_model.parse::<BudgetModel>().ok()
+            },
         })
     }
 }

--- a/src/app/config_file.rs
+++ b/src/app/config_file.rs
@@ -25,6 +25,17 @@ pub struct ConfigFile {
     pub commands: CommandsConfig,
     /// Event hooks
     pub hooks: HooksConfig,
+    /// Context budget bar settings
+    pub budget: BudgetConfig,
+}
+
+/// Context budget bar settings (`[budget]` section in config.toml)
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct BudgetConfig {
+    /// Default model used by the budget bar (e.g. "sonnet-4-6-200k").
+    /// Empty string means "use the built-in default".
+    pub default_model: String,
 }
 
 /// General application settings

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -83,6 +83,9 @@ pub fn run_app(
     state.pick_mode = config.pick_mode;
     state.select_mode = config.select_mode;
     state.multi_select = config.multi_select;
+    if let Some(model) = config.budget_default_model {
+        state.budget_model = model;
+    }
 
     // Apply config file settings
     state.show_hidden = config.show_hidden;
@@ -334,6 +337,21 @@ pub fn run_app(
                 }
                 needs_redraw = true;
             }
+        }
+
+        // Sync the budget bar's marked-token cache with the current
+        // selection set. Bulk operations (Select All, Invert, etc.) mutate
+        // selected_paths directly, so we reconcile here rather than wiring
+        // every action handler. Then drain any worker results that arrived
+        // since the last frame.
+        let sync_added = {
+            let before = state.marked_token_cache.len();
+            state.sync_budget_cache();
+            state.marked_token_cache.len() != before
+        };
+        let drained = state.drain_budget_results();
+        if sync_added || drained > 0 {
+            needs_redraw = true;
         }
 
         // Git status polling (configurable interval)

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,12 +1,13 @@
 //! Application state management
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use super::{FocusTarget, ViewMode};
 use crate::action::Clipboard;
 use crate::ai_activity::AiActivityState;
 use crate::git::GitStatus;
+use crate::integrate::{BudgetModel, BudgetWorker};
 
 /// Number of bookmark slots (1-9)
 pub const BOOKMARK_SLOTS: usize = 9;
@@ -206,6 +207,14 @@ pub struct AppState {
     pub ai_history: Vec<AiHistoryEntry>,
     /// Live AI activity reflection (MCP tool calls streamed from the server)
     pub ai_activity: AiActivityState,
+    /// Currently selected target model for the context budget bar
+    pub budget_model: BudgetModel,
+    /// Per-path token estimate cache. `None` means a worker has been asked
+    /// for the count but the result has not arrived yet.
+    pub marked_token_cache: HashMap<PathBuf, Option<usize>>,
+    /// Background token estimator. Lazily spawned when the first file is
+    /// marked, so non-AI users never pay the thread cost.
+    pub budget_worker: Option<BudgetWorker>,
 }
 
 impl AppState {
@@ -251,7 +260,113 @@ impl AppState {
             ai_focus_prev_preview_display_mode: PreviewDisplayMode::default(),
             ai_history: Vec::new(),
             ai_activity: AiActivityState::default(),
+            budget_model: BudgetModel::default(),
+            marked_token_cache: HashMap::new(),
+            budget_worker: None,
         }
+    }
+
+    /// Ensure a budget worker is running and return it.
+    fn ensure_budget_worker(&mut self) -> &BudgetWorker {
+        if self.budget_worker.is_none() {
+            self.budget_worker = Some(BudgetWorker::spawn());
+        }
+        self.budget_worker.as_ref().expect("just spawned")
+    }
+
+    /// Hook to call when a path is newly marked. Adds a placeholder cache
+    /// entry and queues a background token estimation for the path.
+    pub fn on_path_marked(&mut self, path: &PathBuf) {
+        if self.marked_token_cache.contains_key(path) {
+            return;
+        }
+        self.marked_token_cache.insert(path.clone(), None);
+        let worker = self.ensure_budget_worker();
+        let _ = worker.enqueue(path.clone());
+    }
+
+    /// Hook to call when a path is unmarked. Removes the cache entry.
+    pub fn on_path_unmarked(&mut self, path: &PathBuf) {
+        self.marked_token_cache.remove(path);
+    }
+
+    /// Hook to call when the entire selection is cleared.
+    pub fn on_selection_cleared(&mut self) {
+        self.marked_token_cache.clear();
+    }
+
+    /// Sync `marked_token_cache` against `selected_paths`.
+    ///
+    /// Adds missing entries (and queues token estimation for them) and
+    /// removes stale entries. Useful when bulk operations like `Select All`
+    /// or `Invert Selection` mutate `selected_paths` directly.
+    pub fn sync_budget_cache(&mut self) {
+        let to_add: Vec<PathBuf> = self
+            .selected_paths
+            .iter()
+            .filter(|p| !self.marked_token_cache.contains_key(*p))
+            .cloned()
+            .collect();
+        let to_remove: Vec<PathBuf> = self
+            .marked_token_cache
+            .keys()
+            .filter(|p| !self.selected_paths.contains(*p))
+            .cloned()
+            .collect();
+        for p in to_remove {
+            self.marked_token_cache.remove(&p);
+        }
+        for p in to_add {
+            self.marked_token_cache.insert(p.clone(), None);
+            let worker = self.ensure_budget_worker();
+            let _ = worker.enqueue(p);
+        }
+    }
+
+    /// Drain pending worker results into the cache.
+    ///
+    /// Returns the number of cache entries that were updated; callers can
+    /// use the value to decide whether to force a redraw.
+    pub fn drain_budget_results(&mut self) -> usize {
+        let Some(worker) = self.budget_worker.as_ref() else {
+            return 0;
+        };
+        let results = worker.drain();
+        let mut updated = 0;
+        for r in results {
+            if !self.marked_token_cache.contains_key(&r.path) {
+                continue;
+            }
+            let val = r.tokens.ok();
+            self.marked_token_cache.insert(r.path, val);
+            updated += 1;
+        }
+        updated
+    }
+
+    /// Total token estimate across files whose count is already known.
+    /// Files still pending estimation are excluded from the total.
+    pub fn known_token_total(&self) -> usize {
+        self.marked_token_cache
+            .values()
+            .filter_map(|v| *v)
+            .sum::<usize>()
+    }
+
+    /// Number of marked files for which the worker has not yet returned a
+    /// count. Used by the status bar to show a `?` indicator while values
+    /// are still settling.
+    pub fn pending_token_count(&self) -> usize {
+        self.marked_token_cache
+            .values()
+            .filter(|v| v.is_none())
+            .count()
+    }
+
+    /// Cycle the budget model and return the new value.
+    pub fn cycle_budget_model(&mut self) -> BudgetModel {
+        self.budget_model = self.budget_model.next();
+        self.budget_model
     }
 
     /// Initialize git status (call after first frame render for faster startup)

--- a/src/handler/action/display.rs
+++ b/src/handler/action/display.rs
@@ -325,6 +325,14 @@ pub fn handle(
                 }
             }
         }
+        KeyAction::CycleBudgetModel => {
+            let new_model = state.cycle_budget_model();
+            state.set_message(format!(
+                "Budget model: {} ({}k window)",
+                new_model.label(),
+                new_model.window_tokens() / 1_000
+            ));
+        }
         _ => {}
     }
     Ok(())

--- a/src/handler/action/mod.rs
+++ b/src/handler/action/mod.rs
@@ -352,7 +352,8 @@ pub fn handle_action(
         | KeyAction::OpenAiActivityLog
         | KeyAction::AiActivityLogUp
         | KeyAction::AiActivityLogDown
-        | KeyAction::AiActivityLogSelect => {
+        | KeyAction::AiActivityLogSelect
+        | KeyAction::CycleBudgetModel => {
             display::handle(action, state, navigator, focused_path)?;
             Ok(ActionResult::Continue)
         }

--- a/src/handler/key.rs
+++ b/src/handler/key.rs
@@ -204,6 +204,8 @@ pub enum KeyAction {
     AiActivityLogDown,
     /// Jump to the path under the AI activity log cursor
     AiActivityLogSelect,
+    /// Cycle the context budget bar's target model
+    CycleBudgetModel,
 }
 
 /// Handle key event and return the resulting action
@@ -412,6 +414,10 @@ fn handle_browse_mode(state: &AppState, key: KeyEvent) -> KeyAction {
         }
         KeyCode::Char('l') | KeyCode::Char('L') if key.modifiers == KeyModifiers::ALT => {
             KeyAction::OpenAiActivityLog
+        }
+        // Context budget bar: cycle target model (Alt+M).
+        KeyCode::Char('m') | KeyCode::Char('M') if key.modifiers == KeyModifiers::ALT => {
+            KeyAction::CycleBudgetModel
         }
         // Quit
         KeyCode::Char('q') => {

--- a/src/integrate/budget.rs
+++ b/src/integrate/budget.rs
@@ -1,0 +1,334 @@
+//! Context budget tracking for AI workflows.
+//!
+//! Keeps a running token estimate for the user's marked file set, plus a
+//! background worker that computes per-file token counts off the UI thread.
+//!
+//! The estimate uses `cl100k_base` via `tiktoken_rs`, which is accurate for
+//! GPT family models and a reasonable approximation for Claude (typically
+//! within 5 to 10 percent). The status bar surface labels the result as
+//! `estimate` to avoid implying byte-exact precision.
+
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread::{self, JoinHandle};
+
+use crate::mcp::token::estimate_file_tokens;
+
+/// Models the budget bar can target.
+///
+/// The variant order is the cycle order driven by `Alt+M`.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BudgetModel {
+    #[default]
+    Sonnet46_200k,
+    Sonnet46_1M,
+    Opus47_200k,
+    Haiku45_200k,
+    Gpt4o_128k,
+}
+
+impl BudgetModel {
+    /// Maximum context window in tokens.
+    pub fn window_tokens(&self) -> usize {
+        match self {
+            Self::Sonnet46_200k => 200_000,
+            Self::Sonnet46_1M => 1_000_000,
+            Self::Opus47_200k => 200_000,
+            Self::Haiku45_200k => 200_000,
+            Self::Gpt4o_128k => 128_000,
+        }
+    }
+
+    /// Long display label, used in non-narrow status bars.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Sonnet46_200k => "Sonnet 4.6",
+            Self::Sonnet46_1M => "Sonnet 4.6 1M",
+            Self::Opus47_200k => "Opus 4.7",
+            Self::Haiku45_200k => "Haiku 4.5",
+            Self::Gpt4o_128k => "GPT-4o",
+        }
+    }
+
+    /// Compact label, used for Narrow and Ultra status bars.
+    pub fn short_label(&self) -> &'static str {
+        match self {
+            Self::Sonnet46_200k => "S4.6",
+            Self::Sonnet46_1M => "S4.6/1M",
+            Self::Opus47_200k => "O4.7",
+            Self::Haiku45_200k => "H4.5",
+            Self::Gpt4o_128k => "4o",
+        }
+    }
+
+    /// Stable string used when persisting to config.
+    pub fn as_config_str(&self) -> &'static str {
+        match self {
+            Self::Sonnet46_200k => "sonnet-4-6-200k",
+            Self::Sonnet46_1M => "sonnet-4-6-1m",
+            Self::Opus47_200k => "opus-4-7-200k",
+            Self::Haiku45_200k => "haiku-4-5-200k",
+            Self::Gpt4o_128k => "gpt-4o-128k",
+        }
+    }
+
+    /// Cycle to the next model, wrapping after the last variant.
+    pub fn next(&self) -> Self {
+        match self {
+            Self::Sonnet46_200k => Self::Sonnet46_1M,
+            Self::Sonnet46_1M => Self::Opus47_200k,
+            Self::Opus47_200k => Self::Haiku45_200k,
+            Self::Haiku45_200k => Self::Gpt4o_128k,
+            Self::Gpt4o_128k => Self::Sonnet46_200k,
+        }
+    }
+}
+
+impl FromStr for BudgetModel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "sonnet-4-6-200k" | "sonnet-4-6" | "sonnet" => Ok(Self::Sonnet46_200k),
+            "sonnet-4-6-1m" | "sonnet-1m" => Ok(Self::Sonnet46_1M),
+            "opus-4-7-200k" | "opus-4-7" | "opus" => Ok(Self::Opus47_200k),
+            "haiku-4-5-200k" | "haiku-4-5" | "haiku" => Ok(Self::Haiku45_200k),
+            "gpt-4o-128k" | "gpt-4o" | "4o" => Ok(Self::Gpt4o_128k),
+            other => Err(format!("unknown budget model: {}", other)),
+        }
+    }
+}
+
+/// One result message from the worker thread.
+#[derive(Debug)]
+pub struct BudgetResult {
+    pub path: PathBuf,
+    pub tokens: Result<usize, String>,
+}
+
+enum BudgetMessage {
+    Estimate(PathBuf),
+    Shutdown,
+}
+
+/// Background worker that computes token counts for paths.
+///
+/// One worker is created per `AppState` and lives for the duration of the
+/// session. It owns a single dedicated thread; tiktoken's BPE table is
+/// initialized once on the worker thread, so the UI thread never pays the
+/// 30 to 80 ms first-call cost.
+pub struct BudgetWorker {
+    tx: Sender<BudgetMessage>,
+    rx: Receiver<BudgetResult>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl BudgetWorker {
+    /// Spawn the worker thread.
+    pub fn spawn() -> Self {
+        let (req_tx, req_rx) = mpsc::channel::<BudgetMessage>();
+        let (res_tx, res_rx) = mpsc::channel::<BudgetResult>();
+
+        let handle = thread::Builder::new()
+            .name("fv-budget-worker".into())
+            .spawn(move || {
+                while let Ok(msg) = req_rx.recv() {
+                    match msg {
+                        BudgetMessage::Shutdown => break,
+                        BudgetMessage::Estimate(path) => {
+                            let tokens = estimate_file_tokens(&path).map_err(|e| e.to_string());
+                            if res_tx.send(BudgetResult { path, tokens }).is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            })
+            .expect("spawn fv-budget-worker thread");
+
+        Self {
+            tx: req_tx,
+            rx: res_rx,
+            handle: Some(handle),
+        }
+    }
+
+    /// Queue a path for token estimation. The result will arrive on the
+    /// channel returned by `try_recv`. Returns false when the worker is gone.
+    pub fn enqueue(&self, path: PathBuf) -> bool {
+        self.tx.send(BudgetMessage::Estimate(path)).is_ok()
+    }
+
+    /// Drain all completed results without blocking.
+    pub fn drain(&self) -> Vec<BudgetResult> {
+        let mut out = Vec::new();
+        while let Ok(r) = self.rx.try_recv() {
+            out.push(r);
+        }
+        out
+    }
+}
+
+impl Drop for BudgetWorker {
+    fn drop(&mut self) {
+        let _ = self.tx.send(BudgetMessage::Shutdown);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Format a token count with a `k` suffix for compact rendering.
+///
+/// Examples: `0` -> `"0"`, `512` -> `"512"`, `1234` -> `"1.2k"`,
+/// `42_000` -> `"42k"`, `2_500_000` -> `"2.5M"`.
+pub fn humanize_tokens(n: usize) -> String {
+    if n < 1_000 {
+        return n.to_string();
+    }
+    if n < 10_000 {
+        return format!("{:.1}k", n as f32 / 1_000.0);
+    }
+    if n < 1_000_000 {
+        return format!("{}k", n / 1_000);
+    }
+    if n < 10_000_000 {
+        return format!("{:.1}M", n as f32 / 1_000_000.0);
+    }
+    format!("{}M", n / 1_000_000)
+}
+
+/// Severity bucket for color decisions in the status bar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetSeverity {
+    Ok,
+    Warn,
+    Hot,
+    Over,
+}
+
+impl BudgetSeverity {
+    /// Classify (used, window) into a bucket.
+    pub fn from_usage(used: usize, window: usize) -> Self {
+        if window == 0 || used == 0 {
+            return Self::Ok;
+        }
+        if used > window {
+            return Self::Over;
+        }
+        let ratio = used as f64 / window as f64;
+        if ratio < 0.5 {
+            Self::Ok
+        } else if ratio < 0.8 {
+            Self::Warn
+        } else {
+            Self::Hot
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cycle_visits_every_variant_once() {
+        let mut seen = Vec::new();
+        let mut cur = BudgetModel::default();
+        for _ in 0..5 {
+            seen.push(cur);
+            cur = cur.next();
+        }
+        assert_eq!(seen.len(), 5);
+        assert_eq!(cur, BudgetModel::default(), "cycle should wrap");
+        for v in [
+            BudgetModel::Sonnet46_200k,
+            BudgetModel::Sonnet46_1M,
+            BudgetModel::Opus47_200k,
+            BudgetModel::Haiku45_200k,
+            BudgetModel::Gpt4o_128k,
+        ] {
+            assert!(seen.contains(&v), "cycle missed {:?}", v);
+        }
+    }
+
+    #[test]
+    fn config_string_roundtrip() {
+        for v in [
+            BudgetModel::Sonnet46_200k,
+            BudgetModel::Sonnet46_1M,
+            BudgetModel::Opus47_200k,
+            BudgetModel::Haiku45_200k,
+            BudgetModel::Gpt4o_128k,
+        ] {
+            let s = v.as_config_str();
+            let parsed: BudgetModel = s.parse().unwrap();
+            assert_eq!(parsed, v, "roundtrip failed for {}", s);
+        }
+    }
+
+    #[test]
+    fn from_str_accepts_friendly_aliases() {
+        assert_eq!(
+            "sonnet".parse::<BudgetModel>().unwrap(),
+            BudgetModel::Sonnet46_200k
+        );
+        assert_eq!(
+            "OPUS".parse::<BudgetModel>().unwrap(),
+            BudgetModel::Opus47_200k
+        );
+        assert_eq!(
+            "Sonnet-1M".parse::<BudgetModel>().unwrap(),
+            BudgetModel::Sonnet46_1M
+        );
+        assert!("gpt-3".parse::<BudgetModel>().is_err());
+    }
+
+    #[test]
+    fn humanize_tokens_examples() {
+        assert_eq!(humanize_tokens(0), "0");
+        assert_eq!(humanize_tokens(512), "512");
+        assert_eq!(humanize_tokens(1234), "1.2k");
+        assert_eq!(humanize_tokens(42_000), "42k");
+        assert_eq!(humanize_tokens(199_999), "199k");
+        assert_eq!(humanize_tokens(2_500_000), "2.5M");
+        assert_eq!(humanize_tokens(15_000_000), "15M");
+    }
+
+    #[test]
+    fn severity_buckets_match_thresholds() {
+        let w = 200_000;
+        assert_eq!(BudgetSeverity::from_usage(0, w), BudgetSeverity::Ok);
+        assert_eq!(BudgetSeverity::from_usage(50_000, w), BudgetSeverity::Ok);
+        assert_eq!(BudgetSeverity::from_usage(120_000, w), BudgetSeverity::Warn);
+        assert_eq!(BudgetSeverity::from_usage(180_000, w), BudgetSeverity::Hot);
+        assert_eq!(BudgetSeverity::from_usage(250_000, w), BudgetSeverity::Over);
+    }
+
+    #[test]
+    fn worker_round_trips_a_known_file() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hello.txt");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "Hello, world!").unwrap();
+
+        let worker = BudgetWorker::spawn();
+        assert!(worker.enqueue(path.clone()));
+
+        let mut got = None;
+        for _ in 0..50 {
+            let drained = worker.drain();
+            if let Some(r) = drained.into_iter().next() {
+                got = Some(r);
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        let r = got.expect("worker must produce a result");
+        assert_eq!(r.path, path);
+        assert!(r.tokens.unwrap() > 0);
+    }
+}

--- a/src/integrate/mod.rs
+++ b/src/integrate/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod ai_ignore;
 pub mod benchmark;
+pub mod budget;
 pub mod callback;
 pub mod claude_init;
 pub mod context;
@@ -22,6 +23,7 @@ pub mod tree;
 
 pub use ai_ignore::{synthesize as synthesize_ai_ignore, AiIgnoreAgent, SynthesisOutcome};
 pub use benchmark::run_ai_benchmark;
+pub use budget::{humanize_tokens, BudgetModel, BudgetResult, BudgetSeverity, BudgetWorker};
 pub use callback::{Callback, CallbackResult};
 pub use claude_init::claude_init;
 pub use context::{build_project_context, output_context};

--- a/src/render/status.rs
+++ b/src/render/status.rs
@@ -21,6 +21,68 @@ use super::theme::theme;
 use crate::core::{
     AppState, InputPurpose, PendingAction, PreviewDisplayMode, SortMode, UiDensity, ViewMode,
 };
+use crate::integrate::{humanize_tokens, BudgetSeverity};
+
+/// Build the spans rendered for the context budget bar.
+///
+/// Returns an empty vector when nothing is selected.
+fn budget_segment_spans(state: &AppState, density: UiDensity) -> Vec<Span<'static>> {
+    if state.selected_paths.is_empty() {
+        return Vec::new();
+    }
+    let t = theme();
+    let used = state.known_token_total();
+    let pending = state.pending_token_count();
+    let window = state.budget_model.window_tokens();
+    let percent = if window > 0 {
+        ((used as f64 / window as f64) * 100.0).round() as u32
+    } else {
+        0
+    };
+    let severity = BudgetSeverity::from_usage(used, window);
+    let color = match severity {
+        BudgetSeverity::Ok => t.git_staged,
+        BudgetSeverity::Warn => t.warning,
+        BudgetSeverity::Hot => t.git_conflict,
+        BudgetSeverity::Over => Color::Magenta,
+    };
+    let used_s = humanize_tokens(used);
+    let win_s = humanize_tokens(window);
+    let pending_marker = if pending > 0 {
+        format!("+{}?", pending)
+    } else {
+        String::new()
+    };
+    let text = match density {
+        UiDensity::Full => format!(
+            "[ctx {}f {}{}/{} {} {}%]",
+            state.selected_paths.len(),
+            used_s,
+            if pending_marker.is_empty() {
+                String::new()
+            } else {
+                format!(" {}", pending_marker)
+            },
+            win_s,
+            state.budget_model.short_label(),
+            percent,
+        ),
+        UiDensity::Compact => format!(
+            "[ctx {}{}/{} {}%]",
+            used_s,
+            if pending_marker.is_empty() {
+                String::new()
+            } else {
+                format!(" {}", pending_marker)
+            },
+            win_s,
+            percent,
+        ),
+        UiDensity::Narrow => format!("[ctx {}/{}]", used_s, win_s),
+        UiDensity::Ultra => format!("[{}]", used_s),
+    };
+    vec![Span::styled(text, Style::default().fg(color))]
+}
 
 /// Render the status bar with adaptive layout based on screen width
 /// Compose the status-bar message, giving AI activity precedence when a
@@ -271,6 +333,15 @@ fn render_ultra_compact_status(frame: &mut Frame, state: &AppState, area: Rect) 
         spans.push(Span::styled("\u{f0b0}", Style::default().fg(t.warning)));
     }
 
+    // Budget segment (single bracketed token count)
+    let budget_spans = budget_segment_spans(state, UiDensity::Ultra);
+    if !budget_spans.is_empty() {
+        if !spans.is_empty() {
+            spans.push(Span::raw(" "));
+        }
+        spans.extend(budget_spans);
+    }
+
     // Help hint only if there's space
     let current_width: usize = spans.iter().map(|s| s.width()).sum();
     if current_width < inner_width.saturating_sub(2) && spans.is_empty() {
@@ -337,6 +408,12 @@ fn render_compact_status(
     if selected_count > 0 {
         spans.push(Span::styled(" | ", Style::default().fg(t.git_ignored)));
         spans.push(Span::raw(format!("Sel:{}", selected_count)));
+    }
+
+    let budget_spans = budget_segment_spans(state, UiDensity::Compact);
+    if !budget_spans.is_empty() {
+        spans.push(Span::styled(" | ", Style::default().fg(t.git_ignored)));
+        spans.extend(budget_spans);
     }
 
     let content = Line::from(spans);
@@ -420,7 +497,7 @@ fn render_narrow_status(
         })
         .unwrap_or_default();
 
-    let stats = format!(
+    let stats_text = format!(
         "{}{}{}",
         file_info,
         if selected_count > 0 {
@@ -430,7 +507,14 @@ fn render_narrow_status(
         },
         clipboard_info
     );
-    let stats_widget = Paragraph::new(stats).block(Block::default().borders(Borders::ALL));
+    let mut stats_spans: Vec<Span<'static>> = vec![Span::raw(stats_text)];
+    let budget_spans = budget_segment_spans(state, UiDensity::Narrow);
+    if !budget_spans.is_empty() {
+        stats_spans.push(Span::raw(" "));
+        stats_spans.extend(budget_spans);
+    }
+    let stats_widget =
+        Paragraph::new(Line::from(stats_spans)).block(Block::default().borders(Borders::ALL));
     frame.render_widget(stats_widget, chunks[1]);
 }
 
@@ -526,7 +610,7 @@ fn render_full_status(
         })
         .unwrap_or_default();
 
-    let stats = format!(
+    let stats_text = format!(
         "{}{}{}",
         file_info,
         if selected_count > 0 {
@@ -536,7 +620,14 @@ fn render_full_status(
         },
         clipboard_info
     );
-    let stats_widget = Paragraph::new(stats).block(Block::default().borders(Borders::ALL));
+    let mut stats_spans: Vec<Span<'static>> = vec![Span::raw(stats_text)];
+    let budget_spans = budget_segment_spans(state, UiDensity::Full);
+    if !budget_spans.is_empty() {
+        stats_spans.push(Span::raw(" "));
+        stats_spans.extend(budget_spans);
+    }
+    let stats_widget =
+        Paragraph::new(Line::from(stats_spans)).block(Block::default().borders(Borders::ALL));
     frame.render_widget(stats_widget, chunks[1]);
 }
 


### PR DESCRIPTION
## Summary

Adds a live token budget indicator to the status bar so users can see
how close their marked file set is to a target model's context window
before sending it to an AI agent.

This is the second task in the post-v2.5 roadmap (after #190
ai-ignore synthesizer). It targets the `D` proposal in
`tasks/proposals/D-context-budget-bar.md`.

## What it looks like

| Width | Rendered segment |
|-------|------------------|
| Full (>= 100) | `[ctx 12f 8.4k/200k S4.6 4%]` |
| Narrow (60-99) | `[ctx 8.4k/200k]` |
| Compact (40-59) | `[ctx 8k/200k 4%]` |
| Ultra (< 40) | `[8k]` |

Severity colors:

- Below 50% of window: green
- 50% to 80%: yellow
- 80% to 100%: red
- Over the window: magenta

When some paths are still being estimated, the segment shows a `+N?`
suffix until the worker catches up.

## How it works

- `BudgetModel` enum with five variants and a stable cycle order.
  Window sizes: Sonnet 4.6 200k, Sonnet 4.6 1M, Opus 4.7 200k, Haiku
  4.5 200k, GPT-4o 128k.
- `BudgetWorker` owns a single dedicated thread that runs
  `tiktoken_rs::cl100k_base` so the UI thread never pays the first
  call's BPE load cost.
- `AppState` gains a per-path token cache and reconciles it against
  `selected_paths` once per frame in `event_loop`. This lets bulk
  selection operations (Select All, Invert Selection, Visual Select,
  Select By Extension, Select Git Changed, etc.) update the budget
  bar without touching every action handler.
- `Alt+M` cycles the target model and surfaces the new label via the
  status message line.
- `[budget].default_model` in `config.toml` persists the choice
  across sessions. Empty value falls back to the built-in default.

## Tradeoffs

- Token estimates use cl100k_base, which is accurate for GPT and a
  rough approximation for Claude (typically within 5 to 10 percent).
  The status bar treats numbers as estimates, matching the existing
  `mcp::token` documentation.
- The worker thread is spawned lazily on first mark, so users who
  never select anything pay zero overhead.

## Tests

7 unit tests in `integrate::budget::tests`:

- `cycle_visits_every_variant_once`
- `config_string_roundtrip`
- `from_str_accepts_friendly_aliases`
- `humanize_tokens_examples`
- `severity_buckets_match_thresholds`
- `worker_round_trips_a_known_file`

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` 992 pass / 16 ignored
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual smoke test: mark files with Space, watch budget segment
      update; cycle models with `Alt+M`; clear marks with Esc and
      confirm segment disappears