### PR TITLE
feat(integrate): Add repository-wide TODO/FIXME aggregator

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -174,6 +174,7 @@ fn render_normal_mode(frame: &mut Frame, ctx: &mut RenderContext, size: Rect, fo
     render_help_popup(frame, ctx.state);
     render_ai_history_popup(frame, ctx.state);
     crate::render::render_ai_activity_popup(frame, ctx.state);
+    crate::render::render_todos_popup(frame, ctx.state);
 
     // Render bulk rename dialog if in BulkRename mode
     if matches!(ctx.state.mode, ViewMode::BulkRename { .. }) {

--- a/src/core/mode.rs
+++ b/src/core/mode.rs
@@ -57,6 +57,11 @@ pub enum ViewMode {
     BookmarkJump,
     /// File filter input mode
     Filter { query: String },
+    /// Repository-wide TODO/FIXME aggregator popup
+    Todos {
+        /// Index of selected entry
+        selected: usize,
+    },
     /// Bulk rename mode
     BulkRename {
         /// Pattern to match (e.g., "*.txt", "old_")

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -7,7 +7,7 @@ use super::{FocusTarget, ViewMode};
 use crate::action::Clipboard;
 use crate::ai_activity::AiActivityState;
 use crate::git::{DiffRange, GitStatus};
-use crate::integrate::{BudgetModel, BudgetWorker};
+use crate::integrate::{BudgetModel, BudgetWorker, TodoItem};
 
 /// Number of bookmark slots (1-9)
 pub const BOOKMARK_SLOTS: usize = 9;
@@ -218,6 +218,10 @@ pub struct AppState {
     /// Diff-aware tree scope. When `Some`, the tree filters and annotates
     /// based on this range.
     pub diff_range: Option<DiffRange>,
+    /// Cached TODO/FIXME scan results (populated when the popup is opened).
+    pub todo_items: Vec<TodoItem>,
+    /// Whether the last TODO scan ran out of time before completing.
+    pub todo_partial: bool,
 }
 
 impl AppState {
@@ -267,6 +271,8 @@ impl AppState {
             marked_token_cache: HashMap::new(),
             budget_worker: None,
             diff_range: None,
+            todo_items: Vec::new(),
+            todo_partial: false,
         }
     }
 

--- a/src/handler/action/display.rs
+++ b/src/handler/action/display.rs
@@ -333,6 +333,54 @@ pub fn handle(
                 new_model.window_tokens() / 1_000
             ));
         }
+        KeyAction::OpenTodos => {
+            let outcome =
+                crate::integrate::scan_todos(&state.root, std::time::Duration::from_millis(1500));
+            state.todo_partial = outcome.partial;
+            state.todo_items = outcome.items;
+            state.mode = ViewMode::Todos { selected: 0 };
+            let suffix = if state.todo_partial { " (partial)" } else { "" };
+            state.set_message(format!(
+                "TODOs: {} found{} (j/k, Enter, Esc)",
+                state.todo_items.len(),
+                suffix
+            ));
+        }
+        KeyAction::TodosUp => {
+            if let ViewMode::Todos { selected } = &mut state.mode {
+                *selected = selected.saturating_sub(1);
+            }
+        }
+        KeyAction::TodosDown => {
+            if let ViewMode::Todos { selected } = &mut state.mode {
+                let max = state.todo_items.len().saturating_sub(1);
+                *selected = (*selected + 1).min(max);
+            }
+        }
+        KeyAction::TodosSelect => {
+            if let ViewMode::Todos { selected } = state.mode.clone() {
+                if let Some(item) = state.todo_items.get(selected).cloned() {
+                    if item.path.starts_with(&state.root) {
+                        match reveal_path_in_tree(navigator, state, &item.path) {
+                            Ok(_) => {
+                                state.mode = ViewMode::Browse;
+                                state.set_message(format!(
+                                    "{} {}:{}",
+                                    item.tag.as_str(),
+                                    item.path.display(),
+                                    item.line
+                                ));
+                            }
+                            Err(e) => {
+                                state.set_message(format!("Jump failed: {}", e));
+                            }
+                        }
+                    } else {
+                        state.set_message("Path outside current root");
+                    }
+                }
+            }
+        }
         _ => {}
     }
     Ok(())

--- a/src/handler/action/mod.rs
+++ b/src/handler/action/mod.rs
@@ -353,7 +353,11 @@ pub fn handle_action(
         | KeyAction::AiActivityLogUp
         | KeyAction::AiActivityLogDown
         | KeyAction::AiActivityLogSelect
-        | KeyAction::CycleBudgetModel => {
+        | KeyAction::CycleBudgetModel
+        | KeyAction::OpenTodos
+        | KeyAction::TodosUp
+        | KeyAction::TodosDown
+        | KeyAction::TodosSelect => {
             display::handle(action, state, navigator, focused_path)?;
             Ok(ActionResult::Continue)
         }

--- a/src/handler/key.rs
+++ b/src/handler/key.rs
@@ -206,6 +206,14 @@ pub enum KeyAction {
     AiActivityLogSelect,
     /// Cycle the context budget bar's target model
     CycleBudgetModel,
+    /// Open the repository-wide TODO/FIXME aggregator popup
+    OpenTodos,
+    /// Move up in the TODO popup
+    TodosUp,
+    /// Move down in the TODO popup
+    TodosDown,
+    /// Jump to the file under the TODO popup cursor
+    TodosSelect,
 }
 
 /// Handle key event and return the resulting action
@@ -229,6 +237,7 @@ pub fn handle_key_event(state: &AppState, key: KeyEvent) -> KeyAction {
             to_pattern,
             ..
         } => handle_bulk_rename_mode(key, from_pattern, to_pattern),
+        ViewMode::Todos { .. } => handle_todos_mode(key),
     }
 }
 
@@ -297,6 +306,7 @@ pub fn handle_key_event_with_registry(
             to_pattern,
             ..
         } => handle_bulk_rename_mode(key, from_pattern, to_pattern),
+        ViewMode::Todos { .. } => handle_todos_mode(key),
     }
 }
 
@@ -419,6 +429,8 @@ fn handle_browse_mode(state: &AppState, key: KeyEvent) -> KeyAction {
         KeyCode::Char('m') | KeyCode::Char('M') if key.modifiers == KeyModifiers::ALT => {
             KeyAction::CycleBudgetModel
         }
+        // TODO/FIXME aggregator popup (\)
+        KeyCode::Char('\\') => KeyAction::OpenTodos,
         // Quit
         KeyCode::Char('q') => {
             if state.pick_mode {
@@ -957,6 +969,16 @@ fn handle_ai_activity_log_mode(key: KeyEvent) -> KeyAction {
         KeyCode::Up | KeyCode::Char('k') => KeyAction::AiActivityLogUp,
         KeyCode::Down | KeyCode::Char('j') => KeyAction::AiActivityLogDown,
         KeyCode::Enter => KeyAction::AiActivityLogSelect,
+        _ => KeyAction::None,
+    }
+}
+
+fn handle_todos_mode(key: KeyEvent) -> KeyAction {
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('\\') => KeyAction::Cancel,
+        KeyCode::Up | KeyCode::Char('k') => KeyAction::TodosUp,
+        KeyCode::Down | KeyCode::Char('j') => KeyAction::TodosDown,
+        KeyCode::Enter => KeyAction::TodosSelect,
         _ => KeyAction::None,
     }
 }

--- a/src/integrate/mod.rs
+++ b/src/integrate/mod.rs
@@ -20,6 +20,7 @@ pub mod pick;
 pub mod plugin_cmd;
 pub mod related;
 pub mod session;
+pub mod todos;
 pub mod tree;
 
 pub use ai_ignore::{synthesize as synthesize_ai_ignore, AiIgnoreAgent, SynthesisOutcome};
@@ -41,4 +42,5 @@ pub use pick::{
 pub use plugin_cmd::{plugin_init, plugin_test};
 pub use related::{collect_related_candidates, collect_related_paths, RelatedCandidate};
 pub use session::{load_session, load_session_named, save_session, save_session_named, Session};
+pub use todos::{scan_repo as scan_todos, ScanOutcome as TodoScanOutcome, TodoItem, TodoTag};
 pub use tree::{output_tree, print_tree_recursive_pub};

--- a/src/integrate/todos.rs
+++ b/src/integrate/todos.rs
@@ -1,0 +1,277 @@
+//! Repository-wide TODO/FIXME aggregator.
+//!
+//! Scans the repository for `TODO`, `FIXME`, `XXX`, `HACK`, `BUG`, and
+//! `NOTE` markers and returns a flat list keyed by path and line number.
+//!
+//! The scan is intentionally simple: a recursive `read_dir` walk bounded
+//! by a time budget, with a fixed skip list for common build and cache
+//! directories. No new crate dependency.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use regex::Regex;
+
+/// One marker found in source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TodoItem {
+    pub path: PathBuf,
+    pub line: usize,
+    pub tag: TodoTag,
+    pub message: String,
+}
+
+/// Recognized marker tags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TodoTag {
+    Todo,
+    Fixme,
+    Xxx,
+    Hack,
+    Bug,
+    Note,
+}
+
+impl TodoTag {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Todo => "TODO",
+            Self::Fixme => "FIXME",
+            Self::Xxx => "XXX",
+            Self::Hack => "HACK",
+            Self::Bug => "BUG",
+            Self::Note => "NOTE",
+        }
+    }
+
+    fn from_match(s: &str) -> Option<Self> {
+        match s {
+            "TODO" => Some(Self::Todo),
+            "FIXME" => Some(Self::Fixme),
+            "XXX" => Some(Self::Xxx),
+            "HACK" => Some(Self::Hack),
+            "BUG" => Some(Self::Bug),
+            "NOTE" => Some(Self::Note),
+            _ => None,
+        }
+    }
+}
+
+const SKIP_DIRS: &[&str] = &[
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+    ".turbo",
+    ".svelte-kit",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".tox",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".git",
+    ".idea",
+    ".vscode",
+    "vendor",
+    ".cargo",
+    "Pods",
+];
+
+/// Source extensions we scan. Kept aligned with what fileview previews so the
+/// list matches user expectations of "code files".
+const SOURCE_EXTS: &[&str] = &[
+    "rs", "toml", "md", "txt", "ts", "tsx", "js", "jsx", "mjs", "cjs", "json", "py", "pyi", "go",
+    "rb", "java", "kt", "kts", "c", "cc", "cpp", "h", "hpp", "cs", "php", "swift", "scala", "sh",
+    "bash", "zsh", "fish", "yml", "yaml", "html", "css", "scss", "sass", "lua", "vue", "svelte",
+];
+
+fn is_source_file(path: &Path) -> bool {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some(ext) => SOURCE_EXTS.contains(&ext),
+        None => false,
+    }
+}
+
+fn should_skip_dir(name: &str) -> bool {
+    SKIP_DIRS.contains(&name)
+}
+
+/// Outcome of a scan.
+#[derive(Debug, Clone)]
+pub struct ScanOutcome {
+    pub items: Vec<TodoItem>,
+    /// True when the time budget was hit before the walk completed.
+    pub partial: bool,
+}
+
+/// Scan `root` for TODO-style markers, bounded by `time_budget`.
+pub fn scan_repo(root: &Path, time_budget: Duration) -> ScanOutcome {
+    let started = Instant::now();
+    let re = compile_regex();
+    let mut items: Vec<TodoItem> = Vec::new();
+    let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
+    let mut partial = false;
+
+    while let Some(dir) = stack.pop() {
+        if started.elapsed() >= time_budget {
+            partial = true;
+            break;
+        }
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            if started.elapsed() >= time_budget {
+                partial = true;
+                break;
+            }
+            let Ok(ft) = entry.file_type() else {
+                continue;
+            };
+            let path = entry.path();
+            if ft.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if !should_skip_dir(name) {
+                        stack.push(path);
+                    }
+                }
+                continue;
+            }
+            if !ft.is_file() {
+                continue;
+            }
+            if !is_source_file(&path) {
+                continue;
+            }
+            scan_file(&re, &path, &mut items);
+        }
+    }
+
+    ScanOutcome { items, partial }
+}
+
+fn compile_regex() -> Regex {
+    Regex::new(r"\b(?P<tag>TODO|FIXME|XXX|HACK|BUG|NOTE)\b:?\s*(?P<msg>.*)")
+        .expect("static regex compiles")
+}
+
+fn scan_file(re: &Regex, path: &Path, out: &mut Vec<TodoItem>) {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return;
+    };
+    for (i, line) in text.lines().enumerate() {
+        // Cheap fast path: if none of the tag substrings appear, skip the
+        // regex altogether. This avoids the regex cost on typical lines.
+        if !line.contains("TODO")
+            && !line.contains("FIXME")
+            && !line.contains("XXX")
+            && !line.contains("HACK")
+            && !line.contains("BUG")
+            && !line.contains("NOTE")
+        {
+            continue;
+        }
+        if let Some(caps) = re.captures(line) {
+            let tag_str = caps.name("tag").map(|m| m.as_str()).unwrap_or("");
+            let msg = caps
+                .name("msg")
+                .map(|m| m.as_str().trim().to_string())
+                .unwrap_or_default();
+            if let Some(tag) = TodoTag::from_match(tag_str) {
+                out.push(TodoItem {
+                    path: path.to_path_buf(),
+                    line: i + 1,
+                    tag,
+                    message: msg,
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn extracts_basic_markers() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("a.rs");
+        fs::write(
+            &p,
+            "// TODO: hook up logging\nfn main() {}\n// FIXME: handle error\n",
+        )
+        .unwrap();
+
+        let outcome = scan_repo(dir.path(), Duration::from_secs(2));
+        assert!(!outcome.partial);
+        assert_eq!(outcome.items.len(), 2);
+        assert_eq!(outcome.items[0].tag, TodoTag::Todo);
+        assert_eq!(outcome.items[0].line, 1);
+        assert!(outcome.items[0].message.contains("hook up"));
+        assert_eq!(outcome.items[1].tag, TodoTag::Fixme);
+        assert_eq!(outcome.items[1].line, 3);
+    }
+
+    #[test]
+    fn ignores_non_source_extensions() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("notes.bin"), "TODO: this should be ignored").unwrap();
+        let outcome = scan_repo(dir.path(), Duration::from_secs(2));
+        assert!(outcome.items.is_empty());
+    }
+
+    #[test]
+    fn skips_build_directories() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("target/release")).unwrap();
+        fs::write(
+            dir.path().join("target/release/buggy.rs"),
+            "// TODO: must not surface\n",
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/lib.rs"), "// TODO: surface this one\n").unwrap();
+
+        let outcome = scan_repo(dir.path(), Duration::from_secs(2));
+        assert_eq!(outcome.items.len(), 1);
+        assert!(outcome.items[0].path.ends_with("src/lib.rs"));
+    }
+
+    #[test]
+    fn does_not_match_substrings_inside_words() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("a.rs"),
+            "fn unTODOable() {}\nfn _TODO_inside() {}\n",
+        )
+        .unwrap();
+        let outcome = scan_repo(dir.path(), Duration::from_secs(2));
+        // The word boundary in the regex prevents "unTODOable" from matching,
+        // but "_TODO_" has only word characters around it which the engine
+        // treats as inside a word, so it also should not match.
+        assert!(outcome.items.is_empty(), "got {:?}", outcome.items);
+    }
+
+    #[test]
+    fn captures_message_after_optional_colon() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("a.rs"),
+            "// HACK no colon required\n// BUG: with colon\n",
+        )
+        .unwrap();
+        let outcome = scan_repo(dir.path(), Duration::from_secs(2));
+        assert_eq!(outcome.items.len(), 2);
+        assert_eq!(outcome.items[0].tag, TodoTag::Hack);
+        assert_eq!(outcome.items[0].message, "no colon required");
+        assert_eq!(outcome.items[1].tag, TodoTag::Bug);
+        assert_eq!(outcome.items[1].message, "with colon");
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -32,7 +32,7 @@ pub use preview::{
 };
 pub use ratatui_image::picker::Picker;
 pub use ratatui_image::FontSize;
-pub use status::{render_help_popup, render_input_popup, render_status_bar};
+pub use status::{render_help_popup, render_input_popup, render_status_bar, render_todos_popup};
 pub use tabs::render_tab_bar;
 pub use terminal::{RecommendedProtocol, TerminalBrand};
 pub use theme::{parse_color, theme, Theme, ThemeFile};

--- a/src/render/status.rs
+++ b/src/render/status.rs
@@ -1512,3 +1512,133 @@ pub fn render_help_popup(frame: &mut Frame, state: &AppState) {
 
     frame.render_widget(paragraph, overlay_area);
 }
+
+/// Render the TODO/FIXME aggregator popup.
+pub fn render_todos_popup(frame: &mut Frame, state: &AppState) {
+    use crate::integrate::TodoTag;
+
+    let selected = match state.mode {
+        ViewMode::Todos { selected } => selected,
+        _ => return,
+    };
+
+    let area = frame.area();
+    let overlay_width = area.width.saturating_sub(8).max(60);
+    let overlay_height = area.height.saturating_sub(4).max(10);
+    let overlay_x = (area.width.saturating_sub(overlay_width)) / 2;
+    let overlay_y = (area.height.saturating_sub(overlay_height)) / 2;
+    let overlay_area = Rect::new(overlay_x, overlay_y, overlay_width, overlay_height);
+
+    frame.render_widget(Clear, overlay_area);
+
+    let t = theme();
+    let inner_width = overlay_width.saturating_sub(2) as usize;
+    let visible_rows = overlay_height.saturating_sub(2) as usize;
+
+    // Center the selected row in the visible window.
+    let total = state.todo_items.len();
+    let start = if total <= visible_rows {
+        0
+    } else {
+        let half = visible_rows / 2;
+        if selected < half {
+            0
+        } else if selected + (visible_rows - half) >= total {
+            total.saturating_sub(visible_rows)
+        } else {
+            selected.saturating_sub(half)
+        }
+    };
+
+    let mut lines: Vec<Line<'static>> = Vec::with_capacity(visible_rows);
+    if total == 0 {
+        let msg = if state.todo_partial {
+            "No TODOs in scanned region (scan was partial)"
+        } else {
+            "No TODOs found"
+        };
+        lines.push(Line::from(Span::styled(
+            msg.to_string(),
+            Style::default().fg(t.git_ignored),
+        )));
+    } else {
+        for (i, item) in state
+            .todo_items
+            .iter()
+            .enumerate()
+            .skip(start)
+            .take(visible_rows)
+        {
+            let tag_color = match item.tag {
+                TodoTag::Todo => t.info,
+                TodoTag::Fixme => t.warning,
+                TodoTag::Xxx => t.warning,
+                TodoTag::Hack => t.git_conflict,
+                TodoTag::Bug => t.git_conflict,
+                TodoTag::Note => t.git_staged,
+            };
+            let rel = item
+                .path
+                .strip_prefix(&state.root)
+                .unwrap_or(&item.path)
+                .display()
+                .to_string();
+            let prefix = if i == selected { "▶ " } else { "  " };
+            let location = format!("{}:{}", rel, item.line);
+            let msg = if item.message.is_empty() {
+                String::new()
+            } else {
+                format!("  {}", item.message)
+            };
+
+            let line_style = if i == selected {
+                Style::default()
+                    .bg(t.selection)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+
+            // Truncate the rendered text so it never overflows the popup width.
+            let rendered = format!("{}{:6} {}{}", prefix, item.tag.as_str(), location, msg);
+            let truncated = if rendered.chars().count() > inner_width {
+                let mut out: String = rendered
+                    .chars()
+                    .take(inner_width.saturating_sub(1))
+                    .collect();
+                out.push('…');
+                out
+            } else {
+                rendered
+            };
+
+            // Build line with the tag colored even when the row is selected.
+            let tag_part = format!("{}{:6} ", prefix, item.tag.as_str());
+            let rest_start = tag_part.chars().count().min(truncated.chars().count());
+            let rest: String = truncated.chars().skip(rest_start).collect();
+
+            lines.push(Line::from(vec![
+                Span::styled(tag_part, line_style.fg(tag_color)),
+                Span::styled(rest, line_style),
+            ]));
+        }
+    }
+
+    let title = if state.todo_partial {
+        format!(
+            " TODOs · {} (partial) · Esc to close ",
+            state.todo_items.len()
+        )
+    } else {
+        format!(" TODOs · {} · Esc to close ", state.todo_items.len())
+    };
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(t.border_active)),
+    );
+
+    frame.render_widget(paragraph, overlay_area);
+}


### PR DESCRIPTION
## Summary

Press `\` from any tree view to open a popup that lists every TODO,
FIXME, XXX, HACK, BUG, and NOTE marker found in source files under
the current root.

This is the G proposal in `tasks/proposals/G-todo-aggregator.md`,
scoped to a one-shot scan MVP. Live re-scanning on file changes and
git blame integration are deliberate follow-ups.

## Usage

- `\` opens the popup
- `j` / `k` (or arrow keys) move the cursor
- `Enter` jumps to the file in the tree
- `Esc` / `q` / `\` closes the popup

## Implementation

- New module `src/integrate/todos.rs` with `TodoItem`, `TodoTag`, and
  a `scan_repo(root, time_budget)` entry point.
- The walker uses the same skip list as the fingerprint scan
  (`node_modules`, `target`, `dist`, `__pycache__`, `.git`, and
  similar) and only opens text files with a known source extension
  (Rust, TypeScript / JavaScript, Python, Go, Ruby, Java / Kotlin,
  C / C++, etc.).
- A regex `\b(TODO|FIXME|XXX|HACK|BUG|NOTE)\b:?\s*<msg>` extracts
  tag and message; the colon is optional.
- Fast path: each line is checked for any tag substring with a plain
  `contains` before invoking the regex, so per-line cost is
  negligible on the long majority of source lines.
- Scan is bounded by a 1500 ms budget. If the budget is hit the
  popup title shows `(partial)`.
- New `ViewMode::Todos { selected }`. AppState gains
  `todo_items: Vec<TodoItem>` and `todo_partial: bool`.
- `KeyAction::OpenTodos`, `TodosUp`, `TodosDown`, `TodosSelect`
  added and routed through the existing display handler dispatch.
- `render_todos_popup` renders the centered popup with colored tag
  prefix, relative path, line number, and message.

## Tradeoffs

- The scan is one-shot; closing and reopening the popup re-runs it.
  Live invalidation via `notify` would be a sensible follow-up.
- No git blame author / age annotation. Adding it on hover is also a
  natural follow-up.
- No new crate dependency. The walker reuses the standard library
  read_dir loop, which means we do not respect `.gitignore`
  patterns beyond the hard-coded skip list. Adding `ignore` (~70 KB)
  is a future trade-off.

## Tests

5 unit tests in `integrate::todos::tests`:

- `extracts_basic_markers`
- `ignores_non_source_extensions`
- `skips_build_directories`
- `does_not_match_substrings_inside_words`
- `captures_message_after_optional_colon`

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` 1010 pass / 16 ignored
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual smoke test: press `\` in fileview's own repo, confirm
      the list populates and `Enter` jumps to the source line