### PR TITLE
feat(ai_activity): Add --replay for past AI sessions

### DIFF
--- a/src/ai_activity/mod.rs
+++ b/src/ai_activity/mod.rs
@@ -24,6 +24,7 @@
 
 pub mod emitter;
 pub mod event;
+pub mod replay;
 pub mod session;
 pub mod watcher;
 
@@ -31,6 +32,7 @@ use std::collections::VecDeque;
 
 pub use emitter::ActivityEmitter;
 pub use event::ActivityEvent;
+pub use replay::read_session_events;
 pub use session::{SessionInfo, SessionMeta, SessionRegistry};
 pub use watcher::ActivityWatcher;
 

--- a/src/ai_activity/replay.rs
+++ b/src/ai_activity/replay.rs
@@ -1,0 +1,89 @@
+//! Read past `activity.jsonl` files for the replay UI.
+//!
+//! Activity logs are append-only JSON-Lines written by the MCP server. The
+//! reader is forgiving: a partial trailing line, a corrupt JSON object, or
+//! an unreadable file degrades to "skip and continue" rather than failing
+//! the whole replay.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use super::ActivityEvent;
+
+/// Parse every well-formed JSON line in `activity_log` into an `ActivityEvent`.
+///
+/// Lines that are empty, partial, or fail to decode are silently skipped so
+/// a crashed MCP server does not poison the entire replay.
+pub fn read_session_events(activity_log: &Path) -> Result<Vec<ActivityEvent>> {
+    if !activity_log.exists() {
+        return Ok(Vec::new());
+    }
+    let raw = std::fs::read_to_string(activity_log)?;
+    let mut out = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(ev) = serde_json::from_str::<ActivityEvent>(trimmed) {
+            out.push(ev);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn write_jsonl(dir: &Path, name: &str, lines: &[&str]) -> PathBuf {
+        let path = dir.join(name);
+        let body = lines.join("\n") + "\n";
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn returns_empty_for_missing_file() {
+        let events = read_session_events(Path::new("/no/such/file")).unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn skips_empty_and_corrupt_lines() {
+        let dir = tempdir().unwrap();
+        let path = write_jsonl(
+            dir.path(),
+            "activity.jsonl",
+            &[
+                "",
+                r#"{"ts":1700000000000,"source":"claude","tool":"read_file","path":"/x/a.rs","summary":null}"#,
+                "this is not json",
+                r#"{"ts":1700000005000,"source":"claude-pid-1234","tool":"write_file","path":"/x/b.rs","summary":"ok"}"#,
+                "   ",
+            ],
+        );
+        let events = read_session_events(&path).unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].tool, "read_file");
+        assert_eq!(events[1].tool, "write_file");
+    }
+
+    #[test]
+    fn handles_partial_trailing_line() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("activity.jsonl");
+        // No newline after the partial JSON to simulate a crashed write.
+        fs::write(
+            &path,
+            "{\"ts\":1700000000000,\"source\":\"claude\",\"tool\":\"read_file\",\"path\":null,\"summary\":null}\n{\"ts\":17000",
+        )
+        .unwrap();
+        let events = read_session_events(&path).unwrap();
+        assert_eq!(events.len(), 1);
+    }
+}

--- a/src/ai_activity/session.rs
+++ b/src/ai_activity/session.rs
@@ -112,6 +112,54 @@ impl SessionRegistry {
         let _ = fs::remove_dir_all(&info.dir);
     }
 
+    /// List every session directory that has a readable `session.json` and an
+    /// `activity.jsonl`, regardless of whether the original PID is still
+    /// alive. The list is sorted by activity-log mtime (newest first), so
+    /// the replay picker shows recent sessions on top.
+    ///
+    /// Unlike `list_alive`, this does not garbage-collect stale entries:
+    /// the replay UI deliberately wants to see history that outlived its
+    /// original `fv` process.
+    pub fn list_history(&self) -> Vec<SessionInfo> {
+        let Ok(entries) = fs::read_dir(&self.base_dir) else {
+            return Vec::new();
+        };
+        let mut out: Vec<(SystemTime, SessionInfo)> = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let meta_file = path.join("session.json");
+            let raw = match fs::read_to_string(&meta_file) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            let meta: SessionMeta = match serde_json::from_str(&raw) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let activity_log = path.join("activity.jsonl");
+            if !activity_log.exists() {
+                continue;
+            }
+            let mtime = fs::metadata(&activity_log)
+                .and_then(|m| m.modified())
+                .unwrap_or(UNIX_EPOCH);
+            out.push((
+                mtime,
+                SessionInfo {
+                    meta,
+                    dir: path,
+                    meta_file,
+                    activity_log,
+                },
+            ));
+        }
+        out.sort_by(|a, b| b.0.cmp(&a.0));
+        out.into_iter().map(|(_, s)| s).collect()
+    }
+
     /// List all sessions currently registered AND alive.
     ///
     /// Stale entries (dead PID / malformed metadata) are garbage-collected.

--- a/src/ai_activity/session.rs
+++ b/src/ai_activity/session.rs
@@ -156,7 +156,7 @@ impl SessionRegistry {
                 },
             ));
         }
-        out.sort_by(|a, b| b.0.cmp(&a.0));
+        out.sort_by_key(|entry| std::cmp::Reverse(entry.0));
         out.into_iter().map(|(_, s)| s).collect()
     }
 

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -133,6 +133,9 @@ pub struct Config {
     /// means a specific revspec like `origin/main..HEAD`. `None` means the
     /// flag was not passed.
     pub diff_scope: Option<Option<String>>,
+    /// `--replay` mode. `Some(None)` opens the session picker; `Some(Some(id))`
+    /// jumps directly to a specific session.
+    pub replay: Option<Option<String>>,
 }
 
 impl Config {
@@ -177,6 +180,7 @@ impl Config {
         let mut resume_ai_session: Option<String> = None;
         let mut follow_ai = false;
         let mut diff_scope: Option<Option<String>> = None;
+        let mut replay: Option<Option<String>> = None;
 
         while let Some(arg) = args.next() {
             match arg.as_str() {
@@ -193,6 +197,19 @@ impl Config {
                         }
                     } else {
                         diff_scope = Some(None);
+                    }
+                }
+                "--replay" => {
+                    let next = args.peek().cloned();
+                    if let Some(value) = next {
+                        if !value.starts_with('-') {
+                            args.next();
+                            replay = Some(Some(value));
+                        } else {
+                            replay = Some(None);
+                        }
+                    } else {
+                        replay = Some(None);
                     }
                 }
                 "--choosedir" => {
@@ -566,6 +583,7 @@ impl Config {
                 config_file.budget.default_model.parse::<BudgetModel>().ok()
             },
             diff_scope,
+            replay,
         })
     }
 }
@@ -699,6 +717,11 @@ CLAUDE CODE INTEGRATION:
     --diff [REV]        Diff-aware tree mode. With no argument, scope is
                         the working tree changes. With a revspec (e.g.
                         origin/main..HEAD) the scope is that range.
+    --replay [ID]       Replay past AI sessions recorded under the cache.
+                        With no argument, the session picker opens. With
+                        an ID (the original pid), jump straight to that
+                        session's event timeline. On Enter, the path of
+                        the focused event is printed to stdout.
     plugin init [PATH]  Create plugin template file (default: ~/.config/fileview/plugins/init.lua)
     plugin test PATH    Execute plugin file in sandbox and report status
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10,6 +10,7 @@ mod image_loader;
 mod preview;
 mod preview_worker;
 mod render;
+pub mod replay;
 mod video;
 
 pub use config::{Config, InitAction, PluginAction, SessionAction};
@@ -17,6 +18,7 @@ pub use config_file::{CommandsConfig, ConfigFile, HooksConfig, PreviewConfig};
 pub use event_loop::{run_app, AppResult};
 pub use image_loader::ImageLoader;
 pub use preview::PreviewState;
+pub use replay::{print_outcome as print_replay_outcome, run_replay_app, ReplayOutcome};
 pub use video::{
     extract_thumbnail, find_ffmpeg, find_ffprobe, get_metadata, is_video_file, VideoMetadata,
 };

--- a/src/app/replay.rs
+++ b/src/app/replay.rs
@@ -1,0 +1,457 @@
+//! Replay UI for past `fv --mcp-server` activity.
+//!
+//! Two-pane TUI flow:
+//!
+//! 1. **Session picker** — lists every session directory under
+//!    `<cache>/fileview/sessions/` with a readable `session.json` and an
+//!    `activity.jsonl`. The list is sorted by activity-log mtime so recent
+//!    sessions appear on top.
+//! 2. **Event scrub** — once a session is chosen, lists every event in its
+//!    `activity.jsonl`. `j` / `k` (or arrows) move; `Enter` exits the replay
+//!    UI and prints the selected event's path to stdout so the parent shell
+//!    can hand it back to a fresh `fv`.
+//!
+//! Implementation notes:
+//!
+//! - This runs on its own terminal session (alternate screen, raw mode); it
+//!   does not reuse `run_app`'s loop because there is no tree, no preview,
+//!   no clipboard work, etc.
+//! - All I/O is best effort. A missing session directory or a malformed
+//!   activity log degrades gracefully to "empty list".
+
+use std::io::{stdout, Stdout, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    prelude::CrosstermBackend,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame, Terminal,
+};
+
+use crate::ai_activity::{read_session_events, ActivityEvent, SessionInfo, SessionRegistry};
+
+/// Outcome of running the replay TUI.
+#[derive(Debug, Clone, Default)]
+pub struct ReplayOutcome {
+    /// When the user selected an event with `Enter`, this is the absolute
+    /// path the parent shell should jump to. May be `None` when the user
+    /// quit without picking anything.
+    pub selected_path: Option<PathBuf>,
+}
+
+/// Run the replay UI. `preselect` is the session directory name (the original
+/// pid as a string) when the user ran `fv --replay <id>`; otherwise the
+/// session picker is shown first.
+pub fn run_replay_app(preselect: Option<&str>) -> anyhow::Result<ReplayOutcome> {
+    let registry = SessionRegistry::new()?;
+    let sessions = registry.list_history();
+
+    if sessions.is_empty() {
+        eprintln!(
+            "No fileview sessions found under {}",
+            registry.base_dir().display()
+        );
+        return Ok(ReplayOutcome::default());
+    }
+
+    let preselected_index =
+        preselect.and_then(|id| sessions.iter().position(|s| matches_session_id(s, id)));
+
+    let mut terminal = enter_terminal()?;
+    let result = match preselected_index {
+        Some(idx) => run_event_scrub(&mut terminal, &sessions[idx]),
+        None => run_two_stage(&mut terminal, &sessions),
+    };
+    leave_terminal(&mut terminal)?;
+    result
+}
+
+fn matches_session_id(s: &SessionInfo, id: &str) -> bool {
+    s.dir
+        .file_name()
+        .map(|n| n.to_string_lossy())
+        .map(|name| name == id)
+        .unwrap_or(false)
+}
+
+fn enter_terminal() -> anyhow::Result<Terminal<CrosstermBackend<Stdout>>> {
+    terminal::enable_raw_mode()?;
+    let mut out = stdout();
+    execute!(out, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(out);
+    Ok(Terminal::new(backend)?)
+}
+
+fn leave_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> anyhow::Result<()> {
+    terminal::disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen, cursor::Show)?;
+    Ok(())
+}
+
+fn run_two_stage(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    sessions: &[SessionInfo],
+) -> anyhow::Result<ReplayOutcome> {
+    let mut selected = 0usize;
+    loop {
+        terminal.draw(|frame| {
+            draw_session_picker(frame, sessions, selected);
+        })?;
+        if !event::poll(Duration::from_millis(250))? {
+            continue;
+        }
+        let ev = event::read()?;
+        let key = match ev {
+            Event::Key(k) if k.kind == KeyEventKind::Press => k,
+            _ => continue,
+        };
+        match navigate_session_picker(key, sessions, &mut selected) {
+            PickerStep::Continue => {}
+            PickerStep::Quit => return Ok(ReplayOutcome::default()),
+            PickerStep::Choose => {
+                let outcome = run_event_scrub(terminal, &sessions[selected])?;
+                if outcome.selected_path.is_some() {
+                    return Ok(outcome);
+                }
+                // Returned with no selection: fall back to the picker.
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PickerStep {
+    Continue,
+    Quit,
+    Choose,
+}
+
+fn navigate_session_picker(
+    key: KeyEvent,
+    sessions: &[SessionInfo],
+    selected: &mut usize,
+) -> PickerStep {
+    let max = sessions.len().saturating_sub(1);
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => PickerStep::Quit,
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => PickerStep::Quit,
+        KeyCode::Up | KeyCode::Char('k') => {
+            *selected = selected.saturating_sub(1);
+            PickerStep::Continue
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            *selected = (*selected + 1).min(max);
+            PickerStep::Continue
+        }
+        KeyCode::Char('g') => {
+            *selected = 0;
+            PickerStep::Continue
+        }
+        KeyCode::Char('G') => {
+            *selected = max;
+            PickerStep::Continue
+        }
+        KeyCode::Enter => PickerStep::Choose,
+        _ => PickerStep::Continue,
+    }
+}
+
+fn run_event_scrub(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    session: &SessionInfo,
+) -> anyhow::Result<ReplayOutcome> {
+    let events = read_session_events(&session.activity_log).unwrap_or_default();
+    let mut selected = 0usize;
+    loop {
+        terminal.draw(|frame| {
+            draw_event_scrub(frame, session, &events, selected);
+        })?;
+        if !event::poll(Duration::from_millis(250))? {
+            continue;
+        }
+        let ev = event::read()?;
+        let key = match ev {
+            Event::Key(k) if k.kind == KeyEventKind::Press => k,
+            _ => continue,
+        };
+        let max = events.len().saturating_sub(1);
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => return Ok(ReplayOutcome::default()),
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                return Ok(ReplayOutcome::default());
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                selected = selected.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                selected = (selected + 1).min(max);
+            }
+            KeyCode::Char('K') => {
+                selected = selected.saturating_sub(10);
+            }
+            KeyCode::Char('J') => {
+                selected = (selected + 10).min(max);
+            }
+            KeyCode::Char('g') => selected = 0,
+            KeyCode::Char('G') => selected = max,
+            KeyCode::Enter => {
+                if let Some(ev) = events.get(selected) {
+                    if let Some(path) = ev.path.clone() {
+                        return Ok(ReplayOutcome {
+                            selected_path: Some(path),
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn draw_session_picker(frame: &mut Frame, sessions: &[SessionInfo], selected: usize) {
+    let area = frame.area();
+    frame.render_widget(Clear, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(3)])
+        .split(area);
+
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "fv --replay",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  past AI sessions  "),
+        Span::styled("j/k", Style::default().fg(Color::Yellow)),
+        Span::raw(" navigate  "),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::raw(" open  "),
+        Span::styled("q", Style::default().fg(Color::Yellow)),
+        Span::raw(" quit"),
+    ]))
+    .block(Block::default().borders(Borders::ALL).title(" Replay "));
+    frame.render_widget(header, chunks[0]);
+
+    let inner_height = chunks[1].height.saturating_sub(2) as usize;
+    let start = list_window_start(selected, sessions.len(), inner_height);
+    let lines: Vec<Line<'static>> = sessions
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(inner_height)
+        .map(|(i, s)| render_session_row(i, s, i == selected))
+        .collect();
+
+    let title = format!(" {} session(s) ", sessions.len());
+    let body = Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title(title));
+    frame.render_widget(body, chunks[1]);
+}
+
+fn render_session_row(_index: usize, info: &SessionInfo, focused: bool) -> Line<'static> {
+    let pid = info
+        .dir
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let root = info.meta.root.display().to_string();
+    let prefix = if focused { "▶ " } else { "  " };
+    let style = if focused {
+        Style::default()
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    Line::from(vec![
+        Span::styled(prefix, style.fg(Color::Cyan)),
+        Span::styled(format!("pid {:>6}  ", pid), style.fg(Color::Yellow)),
+        Span::styled(root, style),
+    ])
+}
+
+fn draw_event_scrub(
+    frame: &mut Frame,
+    session: &SessionInfo,
+    events: &[ActivityEvent],
+    selected: usize,
+) {
+    let area = frame.area();
+    frame.render_widget(Clear, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(3)])
+        .split(area);
+
+    let pid = session
+        .dir
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            format!("session {}", pid),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::raw(session.meta.root.display().to_string()),
+        Span::raw("  "),
+        Span::styled(
+            format!("({} events)", events.len()),
+            Style::default().fg(Color::Gray),
+        ),
+        Span::raw("  "),
+        Span::styled("j/k", Style::default().fg(Color::Yellow)),
+        Span::raw(" step  "),
+        Span::styled("J/K", Style::default().fg(Color::Yellow)),
+        Span::raw(" ±10  "),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::raw(" pick path  "),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::raw(" back"),
+    ]))
+    .block(Block::default().borders(Borders::ALL).title(" Replay "));
+    frame.render_widget(header, chunks[0]);
+
+    let inner_height = chunks[1].height.saturating_sub(2) as usize;
+    let start = list_window_start(selected, events.len(), inner_height);
+    let lines: Vec<Line<'static>> = if events.is_empty() {
+        vec![Line::from(Span::styled(
+            "No events recorded for this session.",
+            Style::default().fg(Color::Gray),
+        ))]
+    } else {
+        events
+            .iter()
+            .enumerate()
+            .skip(start)
+            .take(inner_height)
+            .map(|(i, ev)| render_event_row(i, ev, i == selected, &session.meta.root))
+            .collect()
+    };
+
+    let title = format!(
+        " event {}/{} ",
+        selected.saturating_add(1).min(events.len().max(1)),
+        events.len()
+    );
+    let body = Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title(title));
+    frame.render_widget(body, chunks[1]);
+}
+
+fn render_event_row(
+    _index: usize,
+    ev: &ActivityEvent,
+    focused: bool,
+    root: &std::path::Path,
+) -> Line<'static> {
+    let prefix = if focused { "▶ " } else { "  " };
+    let style = if focused {
+        Style::default()
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    let path_disp = ev.short_path(Some(root));
+    let summary = ev.summary.clone().unwrap_or_default();
+    let suffix = if summary.is_empty() {
+        String::new()
+    } else {
+        format!("  · {}", summary)
+    };
+    Line::from(vec![
+        Span::styled(prefix, style.fg(Color::Cyan)),
+        Span::styled(format!("{:>13} ms  ", ev.ts), style.fg(Color::Gray)),
+        Span::styled(
+            format!("{:<10} ", ev.short_source()),
+            style.fg(Color::Yellow),
+        ),
+        Span::styled(format!("{:<14} ", ev.tool), style.fg(Color::Magenta)),
+        Span::styled(path_disp, style),
+        Span::styled(suffix, style.fg(Color::Gray)),
+    ])
+}
+
+fn list_window_start(selected: usize, total: usize, window: usize) -> usize {
+    if total <= window {
+        return 0;
+    }
+    let half = window / 2;
+    if selected < half {
+        0
+    } else if selected + (window - half) >= total {
+        total.saturating_sub(window)
+    } else {
+        selected.saturating_sub(half)
+    }
+}
+
+/// Print the selected outcome on stdout for shell integration.
+///
+/// The replay TUI runs in alternate-screen mode, so any earlier `println!`
+/// would be erased on exit. This helper is meant to be called *after* the
+/// terminal has been restored.
+pub fn print_outcome(outcome: &ReplayOutcome) {
+    if let Some(path) = outcome.selected_path.as_ref() {
+        let mut stdout = stdout();
+        let _ = writeln!(stdout, "{}", path.display());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_window_centers_selected_when_far_into_list() {
+        // 100 items, 10-row window, cursor at 50: should center.
+        assert_eq!(list_window_start(50, 100, 10), 45);
+    }
+
+    #[test]
+    fn list_window_clamps_to_top() {
+        assert_eq!(list_window_start(2, 100, 10), 0);
+    }
+
+    #[test]
+    fn list_window_clamps_to_bottom() {
+        assert_eq!(list_window_start(98, 100, 10), 90);
+    }
+
+    #[test]
+    fn list_window_zero_when_total_fits() {
+        assert_eq!(list_window_start(3, 5, 10), 0);
+    }
+
+    #[test]
+    fn matches_session_id_compares_dir_name() {
+        let info = SessionInfo {
+            meta: crate::ai_activity::SessionMeta {
+                pid: 42,
+                root: std::path::PathBuf::from("/x"),
+                started_at: 0,
+            },
+            dir: std::path::PathBuf::from("/cache/fileview/sessions/42"),
+            meta_file: std::path::PathBuf::from("/cache/fileview/sessions/42/session.json"),
+            activity_log: std::path::PathBuf::from("/cache/fileview/sessions/42/activity.jsonl"),
+        };
+        assert!(matches_session_id(&info, "42"));
+        assert!(!matches_session_id(&info, "99"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,9 @@ use crossterm::{
 };
 use ratatui::prelude::*;
 
-use fileview::app::{run_app, Config, InitAction, PluginAction, SessionAction};
+use fileview::app::{
+    print_replay_outcome, run_app, run_replay_app, Config, InitAction, PluginAction, SessionAction,
+};
 use fileview::integrate::{
     claude_init, collect_related_candidates, collect_related_paths, exit_code, load_session,
     load_session_named, output_context, output_context_pack_with_options, output_paths,
@@ -53,6 +55,10 @@ fn main() -> ExitCode {
 
     if config.mcp_server {
         return run_mcp_server(&config);
+    }
+
+    if let Some(session_id) = config.replay.as_ref() {
+        return run_replay_mode(session_id.as_deref());
     }
 
     if let Some(ref name) = config.resume_ai_session {
@@ -163,6 +169,20 @@ fn run_mcp_server(config: &Config) -> ExitCode {
         Ok(_) => ExitCode::from(exit_code::SUCCESS as u8),
         Err(e) => {
             eprintln!("Error: {}", e);
+            ExitCode::from(exit_code::ERROR as u8)
+        }
+    }
+}
+
+/// Run the replay UI for past AI sessions.
+fn run_replay_mode(session_id: Option<&str>) -> ExitCode {
+    match run_replay_app(session_id) {
+        Ok(outcome) => {
+            print_replay_outcome(&outcome);
+            ExitCode::from(exit_code::SUCCESS as u8)
+        }
+        Err(e) => {
+            eprintln!("Replay failed: {}", e);
             ExitCode::from(exit_code::ERROR as u8)
         }
     }


### PR DESCRIPTION
## Summary

Adds an interactive replay UI for past `fv --mcp-server` activity.
This is the C proposal in `tasks/proposals/C-ai-session-replay.md`,
scoped to the v1 MVP described there.

## Usage

```bash
fv --replay              # open the session picker
fv --replay 12345        # jump straight to a specific session by pid
```

In the picker:

- `j` / `k` (or arrows) move
- `Enter` opens the selected session
- `q` / `Esc` quits

In the event scrub:

- `j` / `k` step one event, `J` / `K` jump ten, `g` / `G` snap to ends
- `Enter` picks the focused event's path; the UI exits and prints the
  absolute path to stdout
- `Esc` returns to the picker

A shell wrapper can hand the picked path back to a fresh `fv`:

```bash
fvreplay() {
  local p
  p=$(fv --replay) || return $?
  [ -n "$p" ] && fv "$(dirname "$p")"
}
```

## Implementation

- `SessionRegistry::list_history()` lists every session dir with a
  readable `session.json` and `activity.jsonl`, sorted by activity-log
  mtime. Unlike `list_alive`, this does not garbage-collect stale
  entries (replay deliberately wants to see history that outlived the
  original `fv` process).
- `ai_activity::replay::read_session_events` parses jsonl forgivingly:
  empty lines, partial trailing lines, and unparseable lines are
  silently skipped so a crashed MCP server cannot poison the entire
  replay.
- `app::replay::run_replay_app` runs a self-contained TUI loop on
  alternate-screen + raw mode. It does not reuse `run_app`'s loop
  because there is no tree, preview, clipboard, or watcher.
- `Config.replay: Option<Option<String>>` carries the new flag.

## Out of scope (follow-ups)

- Side preview pane showing the focused file's content snapshot at
  that point in the replay (would require the MCP server to record
  content hashes; deferred to v2).
- Auto-play with timeline scrubbing (`Space` to start playback).
- Activity density sparkline at the top of the scrub view.
- File-watcher tail mode so an in-progress session updates live.

## Tests

8 unit tests:

- `ai_activity::replay::tests` (3): missing file, skip empty / corrupt
  lines, partial trailing line.
- `app::replay::tests` (5): viewport centering, top / bottom clamps,
  fits-in-window, session ID match.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` 1018 pass / 16 ignored
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual smoke test: ran `fv --replay` after a Claude Code
      session, picker listed the recorded sessions, scrub showed
      ordered events, Enter exited cleanly with the path on stdout