### PR TITLE
feat(build): Make clipboard optional behind a feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       - name: clippy
         # Note: --all-features is not used because 'chafa' requires a system library
         run: cargo clippy --all-targets -- -D warnings
+      - name: clippy (no default features)
+        run: cargo clippy --all-targets --no-default-features -- -D warnings
       - name: rustdoc
         env:
           RUSTDOCFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,13 @@ name = "fv"
 path = "src/main.rs"
 
 [features]
-default = []
+# Default keeps the full feature set so existing users see no behavior change.
+default = ["clipboard"]
+# System clipboard integration via `arboard`. Disabling drops a small Linux
+# dependency surface (X11 / wayland client libraries) and shrinks the binary;
+# `c` and `Ctrl+Y` then surface a one-line "clipboard support disabled" message
+# instead of writing to the OS clipboard.
+clipboard = ["dep:arboard"]
 # Enable Chafa fallback for better image quality on terminals without native protocol support
 # Requires libchafa (>= 1.8.0) to be installed: brew install chafa (macOS) or apt install libchafa-dev (Linux)
 chafa = ["ratatui-image/chafa-dyn"]
@@ -29,7 +35,7 @@ toml = "1.0"
 dirs = "6.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-arboard = "3.4"
+arboard = { version = "3.4", optional = true }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
 ratatui-image = { version = "10.0.6", default-features = false, features = ["crossterm"] }
 nucleo-matcher = "0.3"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ fv
 ## Install Options
 
 Chafa image support: `cargo install fileview --features chafa`<br>
-Speed-optimized build: `cargo install fileview --profile release-fast`
+Speed-optimized build: `cargo install fileview --profile release-fast`<br>
+Slim build (drops the `arboard` clipboard dependency on Linux):
+`cargo install fileview --no-default-features`
 
 ## Image Preview
 

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -921,8 +921,15 @@ pub fn run_app(
                             let _ = reload_tree(&mut navigator, &mut state);
                         }
                         PluginAction::SetClipboard(text) => {
-                            if let Ok(mut clipboard) = arboard::Clipboard::new() {
-                                let _ = clipboard.set_text(&text);
+                            #[cfg(feature = "clipboard")]
+                            {
+                                if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                                    let _ = clipboard.set_text(&text);
+                                }
+                            }
+                            #[cfg(not(feature = "clipboard"))]
+                            {
+                                let _ = text;
                             }
                         }
                         PluginAction::Focus(path) => {

--- a/src/handler/action/display.rs
+++ b/src/handler/action/display.rs
@@ -13,7 +13,9 @@ use crate::render::{
 };
 use crate::tree::TreeNavigator;
 
-use super::{get_filename_str, reload_tree, ActionContext, ActionResult};
+#[cfg(feature = "clipboard")]
+use super::get_filename_str;
+use super::{reload_tree, ActionContext, ActionResult};
 
 /// Handle app control actions (Quit, QuitAndCd, Cancel)
 pub fn handle_app_control(
@@ -81,20 +83,40 @@ pub fn handle(
         }
         KeyAction::CopyPath => {
             if let Some(path) = focused_path {
-                match arboard::Clipboard::new()
-                    .and_then(|mut cb| cb.set_text(path.display().to_string()))
+                #[cfg(feature = "clipboard")]
                 {
-                    Ok(_) => state.set_message("Copied path"),
-                    Err(_) => state.set_message("Failed: copy path"),
+                    match arboard::Clipboard::new()
+                        .and_then(|mut cb| cb.set_text(path.display().to_string()))
+                    {
+                        Ok(_) => state.set_message("Copied path"),
+                        Err(_) => state.set_message("Failed: copy path"),
+                    }
+                }
+                #[cfg(not(feature = "clipboard"))]
+                {
+                    let _ = path;
+                    state.set_message(
+                        "Clipboard support disabled (rebuild with --features clipboard)",
+                    );
                 }
             }
         }
         KeyAction::CopyFilename => {
             if let Some(path) = focused_path {
-                let name = get_filename_str(Some(path));
-                match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(name)) {
-                    Ok(_) => state.set_message("Copied filename"),
-                    Err(_) => state.set_message("Failed: copy filename"),
+                #[cfg(feature = "clipboard")]
+                {
+                    let name = get_filename_str(Some(path));
+                    match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(name)) {
+                        Ok(_) => state.set_message("Copied filename"),
+                        Err(_) => state.set_message("Failed: copy filename"),
+                    }
+                }
+                #[cfg(not(feature = "clipboard"))]
+                {
+                    let _ = path;
+                    state.set_message(
+                        "Clipboard support disabled (rebuild with --features clipboard)",
+                    );
                 }
             }
         }
@@ -696,10 +718,18 @@ fn copy_file_contents_compact(paths: &[PathBuf]) -> anyhow::Result<(String, usiz
 }
 
 fn copy_text_to_clipboard(text: &str) -> anyhow::Result<()> {
-    arboard::Clipboard::new()
-        .and_then(|mut cb| cb.set_text(text.to_string()))
-        .map_err(|e| anyhow::anyhow!("Clipboard error: {}", e))?;
-    Ok(())
+    #[cfg(feature = "clipboard")]
+    {
+        arboard::Clipboard::new()
+            .and_then(|mut cb| cb.set_text(text.to_string()))
+            .map_err(|e| anyhow::anyhow!("Clipboard error: {}", e))?;
+        Ok(())
+    }
+    #[cfg(not(feature = "clipboard"))]
+    {
+        let _ = text;
+        anyhow::bail!("clipboard support disabled (rebuild with --features clipboard)")
+    }
 }
 
 /// Handle pick mode selection


### PR DESCRIPTION
## Summary

Introduces a `clipboard` feature, on by default, that gates `arboard`
and the four call sites that talk to the OS clipboard. Existing users
see no behavior change.

This is the first step of proposal A (`tasks/proposals/A-feature-flags.md`).
The remaining feature gates (`lua`, `ai`, `archive`, `image`, `pdf`,
`video`) will land as small follow-up PRs without further plumbing
work.

## Slim build

```bash
cargo install fileview --no-default-features
```

Drops the `arboard` dependency, which on Linux pulls in X11 /
wayland system libraries. `c`, `Ctrl+Y`, and the
`PluginAction::SetClipboard` path surface a one-line
"clipboard support disabled" message instead of silently failing.

## What changed

- `Cargo.toml`: `arboard` marked `optional = true`. New `clipboard`
  feature in the `[features]` table. Default set to `["clipboard"]`.
- `src/handler/action/display.rs`: `KeyAction::CopyPath` and
  `CopyFilename` arms guard the `arboard::Clipboard::new()` call;
  `copy_text_to_clipboard` returns an error when the feature is
  off; the `get_filename_str` import is gated likewise.
- `src/app/event_loop.rs`: `PluginAction::SetClipboard` becomes a
  no-op when the feature is off.
- `README.md`: new install option documented.
- `.github/workflows/ci.yml`: Lint job now also runs `cargo clippy
  --all-targets --no-default-features` so slim-build regressions
  are caught on every PR.

## Tradeoffs

- The plumbing is conservative. Each call site keeps a hand-written
  `#[cfg(feature = "clipboard")]` block rather than collapsing into
  a stub module, because the four sites are short and a stub
  module would obscure where clipboard work happens.
- Clippy now runs twice (default + slim) on every Lint job. The
  no-default-features build is fast (no large optional deps yet),
  so the extra time is negligible compared to MSRV / Test.

## Out of scope

Subsequent feature flags from proposal A:

- `lua` (mlua + vendored Lua 5.4): biggest binary win (>200 KB)
- `ai` (tiktoken-rs BPE table + petgraph)
- `archive` (zip + tar + flate2)
- `image`, `pdf`, `video`

Each lands as its own PR following this same pattern.

## Test plan

- [x] `cargo build` with default features
- [x] `cargo build --no-default-features`
- [x] `cargo test` 1018 pass / 16 ignored
- [x] `cargo test --no-default-features` 1018 pass / 16 ignored
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings` clean
- [x] `cargo fmt --check` clean