### PR TITLE
perf(app): Warm syntect and tiktoken in a background thread at startup

### DIFF
--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -81,6 +81,19 @@ pub fn run_app(
     config: Config,
     image_picker: &mut Option<Picker>,
 ) -> anyhow::Result<AppResult> {
+    // Warm the heavy lazy caches in a background thread so the first
+    // preview, syntax highlight, or token estimate doesn't pay the
+    // 30 to 80 ms first-call cost on the UI thread. The thread is
+    // detached: results land in `OnceLock`s shared with the rest of
+    // the app, so we don't need to hold onto a JoinHandle.
+    thread::Builder::new()
+        .name("fv-warmup".into())
+        .spawn(|| {
+            crate::render::warmup_syntax();
+            let _ = crate::mcp::token::estimate_tokens("");
+        })
+        .ok();
+
     let mut state = AppState::new(config.root.clone());
     state.pick_mode = config.pick_mode;
     state.select_mode = config.select_mode;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -26,9 +26,9 @@ pub use preview::{
     calculate_centered_image_area, find_pdftoppm, is_archive_file, is_binary_file, is_image_file,
     is_pdf_file, is_tar_gz_file, is_text_file, render_archive_preview, render_custom_preview,
     render_diff_preview, render_directory_info, render_hex_preview, render_image_preview,
-    render_pdf_preview, render_text_preview, render_video_preview, ArchiveEntry, ArchivePreview,
-    CustomPreview, DiffPreview, DirectoryInfo, HexPreview, ImagePreview, PdfPreview, StyledLine,
-    StyledSegment, TextPreview, VideoPreview,
+    render_pdf_preview, render_text_preview, render_video_preview, warmup_syntax, ArchiveEntry,
+    ArchivePreview, CustomPreview, DiffPreview, DirectoryInfo, HexPreview, ImagePreview,
+    PdfPreview, StyledLine, StyledSegment, TextPreview, VideoPreview,
 };
 pub use ratatui_image::picker::Picker;
 pub use ratatui_image::FontSize;

--- a/src/render/preview/mod.rs
+++ b/src/render/preview/mod.rs
@@ -49,7 +49,10 @@ pub use image::{calculate_centered_image_area, is_image_file, render_image_previ
 pub use pdf::{find_pdftoppm, is_pdf_file, render_pdf_preview, PdfPreview};
 
 // Re-export text preview and detection
-pub use text::{is_text_file, render_text_preview, StyledLine, StyledSegment, TextPreview};
+pub use text::{
+    is_text_file, render_text_preview, warmup as warmup_syntax, StyledLine, StyledSegment,
+    TextPreview,
+};
 
 // Re-export video preview
 pub use video::{render_video_preview, VideoPreview};

--- a/src/render/preview/text.rs
+++ b/src/render/preview/text.rs
@@ -36,6 +36,18 @@ fn get_theme() -> &'static Theme {
     })
 }
 
+/// Warm both lazy caches without doing real work.
+///
+/// First-call cost is roughly 20 to 50 ms for the syntax set and a few
+/// hundred KB of heap for the embedded grammars and theme. Calling this
+/// from a background thread at startup absorbs that cost so the first
+/// preview, the first diff render, and the first Claude / context-pack
+/// invocation do not pay it on the UI thread.
+pub fn warmup() {
+    let _ = get_syntax_set();
+    let _ = get_theme();
+}
+
 /// A segment of styled text (text with color)
 #[derive(Debug, Clone)]
 pub struct StyledSegment {


### PR DESCRIPTION
## Summary

Spawns a detached background thread the moment `run_app` is entered.
The thread calls `render::warmup_syntax()` and a no-op
`mcp::token::estimate_tokens("")` so syntect's grammar / theme load
and tiktoken's `cl100k_base` BPE table parse are absorbed off the UI
thread.

This is the B-1 portion of proposal B
(`tasks/proposals/B-cold-cache.md`). It closes out the eight-step
post-v2.5 roadmap (F, D, A-clipboard, H, E, G, C, B).

## Why

Both `tiktoken_rs::cl100k_base` and `SyntaxSet::load_defaults_newlines`
are roughly 30 to 80 ms on first call. Without warmup, that cost
surfaces on:

- the first preview the user opens
- the first diff render
- the first `Space` toggle that has to feed the budget bar

Those are exactly the moments the user notices a stall. Running
both in a side thread starts them while the user is still seeing
the first frame, and `OnceLock` makes the result available to the
rest of the app once it lands.

## Tradeoffs

- The thread is detached. Failures to spawn (extremely unlikely)
  degrade silently to "no warmup" rather than refusing to start the
  app. The cost is one extra OS thread for ~50 ms.
- The warmup is unconditional. Even users who never open a preview
  pay one tiktoken / syntect cold init. That cost is absorbed off
  the UI thread, so it does not show as a stall, but it does show
  up in `top` for a moment. Acceptable trade for predictable
  responsiveness.

## Out of scope

Proposal B mentions two further changes that are deliberately left
out:

- B-2 (string interning for the path tree): only matters past
  ~50k nodes; revisit when there is a real bug report.
- PGO: gains on fileview's tree-render and fuzzy paths are too
  small to justify the build complexity without measurement.

## Test plan

- [x] `cargo build` with default features
- [x] `cargo build --no-default-features`
- [x] `cargo test` 1018 pass / 16 ignored
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings` clean
- [x] `cargo fmt --check` clean