### PR TITLE
feat(build): Make Lua plugin runtime optional behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,19 @@ path = "src/main.rs"
 
 [features]
 # Default keeps the full feature set so existing users see no behavior change.
-default = ["clipboard"]
+default = ["clipboard", "lua"]
 # System clipboard integration via `arboard`. Disabling drops a small Linux
 # dependency surface (X11 / wayland client libraries) and shrinks the binary;
 # `c` and `Ctrl+Y` then surface a one-line "clipboard support disabled" message
 # instead of writing to the OS clipboard.
 clipboard = ["dep:arboard"]
+# Lua plugin runtime via `mlua` with vendored Lua 5.4. Disabling drops the
+# largest single binary contributor (~200 KB plus runtime) and removes
+# `~/.config/fileview/plugins/init.lua` autoload. CLI subcommand
+# `fv plugin test` returns an error explaining that the feature is off; the
+# rest of the TUI works as before because `PluginManager::new()` simply
+# fails and the optional plugin manager stays `None`.
+lua = ["dep:mlua"]
 # Enable Chafa fallback for better image quality on terminals without native protocol support
 # Requires libchafa (>= 1.8.0) to be installed: brew install chafa (macOS) or apt install libchafa-dev (Linux)
 chafa = ["ratatui-image/chafa-dyn"]
@@ -47,7 +54,7 @@ flate2 = "1.1"
 trash = "5"
 tempfile = "3"
 syntect = "5"
-mlua = { version = "0.11", features = ["lua54", "vendored"] }
+mlua = { version = "0.11", features = ["lua54", "vendored"], optional = true }
 regex = "1"
 # v2.0 additions
 thiserror = "2"          # Unified error types

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ fv
 
 Chafa image support: `cargo install fileview --features chafa`<br>
 Speed-optimized build: `cargo install fileview --profile release-fast`<br>
-Slim build (drops the `arboard` clipboard dependency on Linux):
-`cargo install fileview --no-default-features`
+Slim build (drops the `arboard` clipboard and `mlua` Lua plugin
+dependencies): `cargo install fileview --no-default-features`<br>
+Pick individual features: `cargo install fileview --no-default-features --features clipboard,lua`
 
 ## Image Preview
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -22,7 +22,13 @@
 //! ```
 
 mod api;
+#[cfg(feature = "lua")]
 mod lua;
+#[cfg(not(feature = "lua"))]
+mod stub;
 
 pub use api::{PluginAction, PluginContext, PluginEvent};
+#[cfg(feature = "lua")]
 pub use lua::{PluginError, PluginManager};
+#[cfg(not(feature = "lua"))]
+pub use stub::{PluginError, PluginManager};

--- a/src/plugin/stub.rs
+++ b/src/plugin/stub.rs
@@ -1,0 +1,108 @@
+//! No-op plugin manager used when the `lua` feature is disabled.
+//!
+//! `PluginManager::new()` always returns `Err(PluginError::Disabled)`, which
+//! the event loop handles via `.ok()` so the optional manager stays `None`
+//! for the entire session. The other methods exist so call sites that
+//! happen to hold a `&mut PluginManager` (e.g. `plugin_test`) compile, but
+//! they all degrade to "feature disabled" or no-op.
+
+use std::path::PathBuf;
+
+use super::api::{PluginAction, PluginEvent};
+
+/// Stub error type. Mirrors the variants the real implementation surfaces
+/// to callers, but always lands on `Disabled`.
+#[derive(Debug)]
+pub enum PluginError {
+    /// The `lua` feature was not compiled in.
+    Disabled,
+}
+
+impl std::fmt::Display for PluginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disabled => write!(
+                f,
+                "lua plugin support is not compiled in (rebuild with --features lua)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PluginError {}
+
+/// Stub manager. Constructible only through `new()` to mirror the real API.
+#[derive(Debug, Default)]
+pub struct PluginManager;
+
+impl PluginManager {
+    /// Always returns `Err(Disabled)` so callers fall back to the no-plugin
+    /// path. Mirrors the real `PluginManager::new` signature.
+    pub fn new() -> Result<Self, PluginError> {
+        Err(PluginError::Disabled)
+    }
+
+    pub fn load_plugins(&mut self) -> Result<(), PluginError> {
+        Err(PluginError::Disabled)
+    }
+
+    pub fn update_context(
+        &mut self,
+        _focused: Option<PathBuf>,
+        _root: PathBuf,
+        _selected: Vec<PathBuf>,
+    ) {
+    }
+
+    pub fn fire_event(
+        &mut self,
+        _event: PluginEvent,
+        _arg: Option<&str>,
+    ) -> Result<(), PluginError> {
+        Ok(())
+    }
+
+    pub fn take_notifications(&mut self) -> Vec<String> {
+        Vec::new()
+    }
+
+    pub fn take_actions(&mut self) -> Vec<PluginAction> {
+        Vec::new()
+    }
+
+    pub fn exec(&mut self, _code: &str) -> Result<(), PluginError> {
+        Err(PluginError::Disabled)
+    }
+
+    pub fn eval(&self, _code: &str) -> Result<String, PluginError> {
+        Err(PluginError::Disabled)
+    }
+
+    pub fn has_command(&self, _name: &str) -> bool {
+        false
+    }
+
+    pub fn list_commands(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    pub fn invoke_command(&mut self, _name: &str) -> Result<(), PluginError> {
+        Err(PluginError::Disabled)
+    }
+
+    pub fn has_previewer(&self, _pattern: &str) -> bool {
+        false
+    }
+
+    pub fn list_previewers(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    pub fn find_previewer(&self, _filename: &str) -> Option<String> {
+        None
+    }
+
+    pub fn invoke_previewer(&mut self, _pattern: &str, _path: &str) -> Result<String, PluginError> {
+        Err(PluginError::Disabled)
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a `lua` feature, on by default, that gates the `mlua`
dependency (vendored Lua 5.4) and the entire `src/plugin/lua.rs`
implementation. Existing users see no behavior change.

This is the second feature gate in proposal A
(`tasks/proposals/A-feature-flags.md`), following #197 (clipboard).

## Why

`mlua` with vendored Lua 5.4 is the largest single contributor to
fileview's binary size after `syntect` and `tiktoken-rs`. Many
users never write a plugin, so making the runtime optional is the
biggest single binary win available.

## What changes when `lua` is off

- `~/.config/fileview/plugins/init.lua` is no longer auto-loaded.
  `PluginManager::new()` returns `PluginError::Disabled` and the
  optional plugin manager in the event loop stays `None`.
- `fv plugin test` returns the disabled error.
- `fv plugin init` still works because it only writes a template
  file; it has nothing to do with the runtime.
- `PluginAction` and `PluginEvent` continue to exist (they live in
  `plugin/api.rs`, which has no `mlua` dependency), so the event-
  loop dispatch table compiles without further `#[cfg]` plumbing.

## Slim build

```bash
cargo install fileview --no-default-features                    # smallest
cargo install fileview --no-default-features --features clipboard,lua
cargo install fileview --no-default-features --features clipboard
```

## Implementation

- `Cargo.toml`: `mlua` marked `optional = true`; new `lua` feature
  string; default set to `["clipboard", "lua"]`.
- `src/plugin/mod.rs`: cfg-routes between the real `lua` module and
  a new `stub` module that implements the same surface.
- `src/plugin/stub.rs` (new, ~110 lines): no-op `PluginManager`.
  `new()` always errors with `Disabled`; the rest either no-op or
  return `Disabled`. Mirrors the public methods of the real
  manager exactly so call sites compile against either backend.

## Tests

- `cargo test`: 1018 pass / 16 ignored (default features)
- `cargo test --no-default-features`: 979 pass / 16 ignored
  (the 39 missing tests are the Lua-only suite in
  `src/plugin/lua.rs`)

The CI Lint job (added in #197) runs both default and
no-default-features clippy, so slim-build regressions are caught
on every PR.

## Test plan

- [x] `cargo build` with default features
- [x] `cargo build --no-default-features`
- [x] `cargo test` 1018 pass / 16 ignored
- [x] `cargo test --no-default-features` 979 pass / 16 ignored
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings` clean
- [x] `cargo fmt --check` clean