### PR TITLE
feat(build): Make archive preview optional behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,12 @@ path = "src/main.rs"
 
 [features]
 # Default keeps the full feature set so existing users see no behavior change.
-default = ["clipboard", "lua"]
+default = ["archive", "clipboard", "lua"]
+# Archive preview for `.zip` and `.tar.gz` files. Disabling drops `zip`,
+# `tar`, and `flate2`. `is_archive_file()` continues to return `true` for
+# the matching extensions but the preview pane shows
+# "archive support disabled" instead of the file listing.
+archive = ["dep:zip", "dep:tar", "dep:flate2"]
 # System clipboard integration via `arboard`. Disabling drops a small Linux
 # dependency surface (X11 / wayland client libraries) and shrinks the binary;
 # `c` and `Ctrl+Y` then surface a one-line "clipboard support disabled" message
@@ -48,9 +53,9 @@ ratatui-image = { version = "10.0.6", default-features = false, features = ["cro
 nucleo-matcher = "0.3"
 notify = "8.2"
 notify-debouncer-mini = "0.7"
-zip = "8.3"
-tar = "0.4"
-flate2 = "1.1"
+zip = { version = "8.3", optional = true }
+tar = { version = "0.4", optional = true }
+flate2 = { version = "1.1", optional = true }
 trash = "5"
 tempfile = "3"
 syntect = "5"

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ fv
 
 Chafa image support: `cargo install fileview --features chafa`<br>
 Speed-optimized build: `cargo install fileview --profile release-fast`<br>
-Slim build (drops the `arboard` clipboard and `mlua` Lua plugin
-dependencies): `cargo install fileview --no-default-features`<br>
-Pick individual features: `cargo install fileview --no-default-features --features clipboard,lua`
+Slim build (drops the `arboard` clipboard, `mlua` Lua plugin, and
+`zip` / `tar` / `flate2` archive dependencies):
+`cargo install fileview --no-default-features`<br>
+Pick individual features: `cargo install fileview --no-default-features --features clipboard,lua,archive`
 
 ## Image Preview
 

--- a/src/render/preview/archive.rs
+++ b/src/render/preview/archive.rs
@@ -10,9 +10,9 @@ use ratatui::{
     Frame,
 };
 
-use super::common::{
-    format_size, get_border_style, truncate_entry_name, unix_timestamp_to_date, ARCHIVE_MAX_ENTRIES,
-};
+use super::common::{format_size, get_border_style};
+#[cfg(feature = "archive")]
+use super::common::{truncate_entry_name, unix_timestamp_to_date, ARCHIVE_MAX_ENTRIES};
 
 /// Archive entry information
 #[derive(Debug, Clone)]
@@ -53,6 +53,7 @@ pub struct ArchivePreview {
 
 impl ArchivePreview {
     /// Load archive preview from zip file
+    #[cfg(feature = "archive")]
     pub fn load_zip(path: &Path) -> anyhow::Result<Self> {
         let file = std::fs::File::open(path)?;
         let mut archive = zip::ZipArchive::new(file)?;
@@ -96,7 +97,14 @@ impl ArchivePreview {
         })
     }
 
+    /// Stub when the `archive` feature is off.
+    #[cfg(not(feature = "archive"))]
+    pub fn load_zip(_path: &Path) -> anyhow::Result<Self> {
+        anyhow::bail!("archive support disabled (rebuild with --features archive)")
+    }
+
     /// Load archive preview from tar.gz file
+    #[cfg(feature = "archive")]
     pub fn load_tar_gz(path: &Path) -> anyhow::Result<Self> {
         let file = std::fs::File::open(path)?;
         let decompressed = flate2::read::GzDecoder::new(file);
@@ -145,6 +153,12 @@ impl ArchivePreview {
             file_count,
             scroll: 0,
         })
+    }
+
+    /// Stub when the `archive` feature is off.
+    #[cfg(not(feature = "archive"))]
+    pub fn load_tar_gz(_path: &Path) -> anyhow::Result<Self> {
+        anyhow::bail!("archive support disabled (rebuild with --features archive)")
     }
 
     /// Get visible line count

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,10 +8,11 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use fileview::core::{AppState, InputPurpose, PendingAction, ViewMode};
 use fileview::handler::{handle_key_event, update_input_buffer, KeyAction};
 use fileview::render::{
-    calculate_centered_image_area, is_archive_file, is_binary_file, is_image_file, is_text_file,
-    ArchivePreview, DirectoryInfo, FontSize, HexPreview, RecommendedProtocol, TerminalBrand,
-    TextPreview,
+    calculate_centered_image_area, is_binary_file, is_image_file, is_text_file, DirectoryInfo,
+    FontSize, HexPreview, RecommendedProtocol, TerminalBrand, TextPreview,
 };
+#[cfg(feature = "archive")]
+use fileview::render::{is_archive_file, ArchivePreview};
 use ratatui::layout::Rect;
 use tempfile::TempDir;
 
@@ -5457,6 +5458,7 @@ mod fuzzy_finder_tests {
 // Archive Preview Tests
 // =============================================================================
 
+#[cfg(feature = "archive")]
 mod archive_preview_tests {
     use super::*;
     use std::fs;


### PR DESCRIPTION
## Summary

Introduces an `archive` feature, on by default, that gates `zip`,
`tar`, and `flate2`. Existing users see no behavior change.

This is the third feature gate in proposal A
(`tasks/proposals/A-feature-flags.md`), following #197 (clipboard)
and #199 (lua).

## What changes when `archive` is off

- `is_archive_file()` and `is_tar_gz_file()` keep detecting
  archives by extension.
- `ArchivePreview::load_zip` and `load_tar_gz` return
  "archive support disabled". The preview pane shows the error
  string instead of the file listing.
- `ArchiveEntry`, `ArchivePreview`, and `render_archive_preview`
  stay always-on so the preview dispatch table compiles without
  extra `#[cfg]` plumbing.

## Implementation

- `Cargo.toml`: three deps marked `optional = true`; new `archive`
  feature; default updated to `["archive", "clipboard", "lua"]`.
- `src/render/preview/archive.rs`: real load bodies behind
  `#[cfg(feature = "archive")]`; stub implementations behind
  `#[cfg(not(...))]` that return the disabled error.
- `tests/integration.rs`: the archive preview integration suite
  (53 tests) and the `zip` / `ArchivePreview` imports moved behind
  `#[cfg(feature = "archive")]`.

## Slim build options

```bash
cargo install fileview --no-default-features                       # smallest
cargo install fileview --no-default-features --features archive    # archives only
cargo install fileview --no-default-features --features clipboard,lua,archive
```

## Tests

- `cargo test`: 1018 pass / 16 ignored (default)
- `cargo test --no-default-features`: 965 pass / 16 ignored
  (53 missing tests are the archive preview suite)

## Test plan

- [x] `cargo build` with default features
- [x] `cargo build --no-default-features`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings` clean
- [x] `cargo fmt --check` clean