### PR TITLE
feat(build): Make AI helpers optional behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,14 @@ path = "src/main.rs"
 
 [features]
 # Default keeps the full feature set so existing users see no behavior change.
-default = ["archive", "clipboard", "lua"]
+default = ["ai", "archive", "clipboard", "lua"]
+# AI helpers backed by `tiktoken-rs` (BPE token estimates) and `petgraph`
+# (dependency graph analysis). Disabling drops both crates and switches
+# `estimate_tokens` to a coarse `chars / 4` heuristic so the budget bar,
+# context-pack truncation, and token guards keep functioning at lower
+# precision. MCP dependency tools (`get_dependency_graph`, etc.) return
+# the disabled error when called.
+ai = ["dep:tiktoken-rs", "dep:petgraph"]
 # Archive preview for `.zip` and `.tar.gz` files. Disabling drops `zip`,
 # `tar`, and `flate2`. `is_archive_file()` continues to return `true` for
 # the matching extensions but the preview pane shows
@@ -63,8 +70,8 @@ mlua = { version = "0.11", features = ["lua54", "vendored"], optional = true }
 regex = "1"
 # v2.0 additions
 thiserror = "2"          # Unified error types
-petgraph = "0.8"         # Dependency graph analysis
-tiktoken-rs = "0.9"      # Token estimation for AI context
+petgraph = { version = "0.8", optional = true } # Dependency graph analysis
+tiktoken-rs = { version = "0.9", optional = true } # Token estimation for AI context
 # AI activity reflection: PID alive check across platforms
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ fv
 
 Chafa image support: `cargo install fileview --features chafa`<br>
 Speed-optimized build: `cargo install fileview --profile release-fast`<br>
-Slim build (drops the `arboard` clipboard, `mlua` Lua plugin, and
-`zip` / `tar` / `flate2` archive dependencies):
-`cargo install fileview --no-default-features`<br>
-Pick individual features: `cargo install fileview --no-default-features --features clipboard,lua,archive`
+Slim build (drops `arboard` clipboard, `mlua` Lua plugin,
+`zip` / `tar` / `flate2` archive, and `tiktoken-rs` /  `petgraph`
+AI helper dependencies): `cargo install fileview --no-default-features`<br>
+Pick individual features: `cargo install fileview --no-default-features --features ai,clipboard,lua,archive`
 
 ## Image Preview
 

--- a/src/mcp/handlers/dependency_stub.rs
+++ b/src/mcp/handlers/dependency_stub.rs
@@ -1,0 +1,24 @@
+//! No-op dependency handlers used when the `ai` feature is off.
+//!
+//! Mirrors the public surface of `dependency.rs` so the MCP server's
+//! dispatch table compiles unchanged. Each handler returns
+//! `error_result("ai feature disabled")` so an AI agent calling these
+//! tools gets a clear message instead of a panic.
+
+use std::path::Path;
+
+use super::{error_result, ToolCallResult};
+
+const DISABLED: &str = "ai feature disabled (rebuild with --features ai)";
+
+pub fn get_dependency_graph(_root: &Path, _path: &str, _depth: Option<usize>) -> ToolCallResult {
+    error_result(DISABLED)
+}
+
+pub fn get_import_tree(_root: &Path, _path: &str) -> ToolCallResult {
+    error_result(DISABLED)
+}
+
+pub fn find_circular_deps(_root: &Path, _path: Option<&str>) -> ToolCallResult {
+    error_result(DISABLED)
+}

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -4,6 +4,10 @@
 
 pub mod analysis;
 pub mod context;
+#[cfg(feature = "ai")]
+pub mod dependency;
+#[cfg(not(feature = "ai"))]
+#[path = "dependency_stub.rs"]
 pub mod dependency;
 pub mod file;
 pub mod git;

--- a/src/mcp/token.rs
+++ b/src/mcp/token.rs
@@ -1,29 +1,51 @@
 //! Token estimation for AI context optimization
 //!
 //! Provides token counting and estimation for optimizing context sent to AI models.
+//!
+//! With the `ai` feature enabled, `estimate_tokens` uses `tiktoken-rs`'s
+//! `cl100k_base` BPE which is accurate for GPT-4 and a reasonable
+//! approximation for Claude (within roughly 5 to 10 percent). Without it,
+//! the function falls back to a coarse `chars / 4 + 1` heuristic so the
+//! budget bar, context-pack truncation, and token guards keep working at
+//! lower precision.
 
 use std::path::Path;
+#[cfg(feature = "ai")]
 use std::sync::OnceLock;
 
+#[cfg(feature = "ai")]
 use tiktoken_rs::{cl100k_base, CoreBPE};
 
 use crate::error::{FileviewError, Result};
 
 /// Lazy-initialized tokenizer (cl100k_base - used by GPT-4 and Claude)
+#[cfg(feature = "ai")]
 static TOKENIZER: OnceLock<CoreBPE> = OnceLock::new();
 
 /// Get the shared tokenizer instance
+#[cfg(feature = "ai")]
 fn get_tokenizer() -> &'static CoreBPE {
     TOKENIZER.get_or_init(|| cl100k_base().expect("Failed to initialize tokenizer"))
 }
 
 /// Estimate the number of tokens in a string.
 ///
-/// Uses cl100k_base encoding which is compatible with GPT-4 and provides
-/// a reasonable approximation for Claude models.
+/// With `ai` on, uses `cl100k_base` for an accurate count. Without it,
+/// falls back to `chars / 4 + 1` which lines up with the rough rule of
+/// thumb that English text is about four characters per token.
+#[cfg(feature = "ai")]
 pub fn estimate_tokens(text: &str) -> usize {
     let bpe = get_tokenizer();
     bpe.encode_with_special_tokens(text).len()
+}
+
+/// Coarse fallback used when the `ai` feature is off.
+#[cfg(not(feature = "ai"))]
+pub fn estimate_tokens(text: &str) -> usize {
+    if text.is_empty() {
+        return 0;
+    }
+    text.chars().count() / 4 + 1
 }
 
 /// Estimate tokens for a file by reading its content.


### PR DESCRIPTION
## Summary

Introduces an `ai` feature, on by default, that gates `tiktoken-rs`
(BPE token estimates) and `petgraph` (dependency graph analysis).
Existing users see no behavior change.

This is the fourth feature gate in proposal A
(`tasks/proposals/A-feature-flags.md`), following clipboard / lua /
archive.

## What changes when `ai` is off

- `estimate_tokens` falls back to a coarse `chars / 4 + 1`
  heuristic. The budget bar, context-pack truncation, and token
  guards keep working at reduced precision rather than disappearing.
- The MCP dependency tools (`get_dependency_graph`,
  `get_import_tree`, `find_circular_deps`) return
  "ai feature disabled" so an AI agent calling them gets a clear
  message instead of a panic.

## Implementation

- `Cargo.toml`: `tiktoken-rs` and `petgraph` marked
  `optional = true`; new `ai` feature; default updated to
  `["ai", "archive", "clipboard", "lua"]`.
- `src/mcp/token.rs`: cfg-routes between the `cl100k_base`
  implementation and the fallback heuristic. The tokenizer
  `OnceLock` and tiktoken imports are gated on `ai`.
- `src/mcp/handlers/`: when `ai` is off, `dependency_stub.rs`
  replaces `dependency.rs` via `#[path]` so the MCP dispatch table
  compiles unchanged.

## Tradeoffs

- The fallback token estimate is intentionally coarse so the budget
  bar can keep operating in slim builds. Users who care about
  precise counts should keep `ai` on; the status bar already labels
  these as estimates.
- Two MCP tools become inert when `ai` is off. They were AI-specific
  anyway, so users who chose `--no-default-features` likely also
  don't use the MCP server.

## Tests

- `cargo test`: 1018 pass / 16 ignored (default)
- `cargo test --no-default-features`: 965 pass / 16 ignored
  (delta is the archive preview integration suite that requires
  zip / tar to construct fixtures)

## Test plan

- [x] `cargo build` with default features
- [x] `cargo build --no-default-features`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings` clean
- [x] `cargo fmt --check` clean