### PR TITLE
Add --tokens <path> CLI for one-shot token estimates

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -106,6 +106,8 @@ pub struct Config {
     pub select_related_path: Option<PathBuf>,
     /// Explain related-file selection scoring
     pub explain_selection: bool,
+    /// `--tokens <path>`: print cl100k_base token estimate for the file and exit.
+    pub tokens_path: Option<PathBuf>,
     /// Session action (save/restore/clear) - non-interactive
     pub session_action: Option<SessionAction>,
     /// Plugin command action
@@ -168,6 +170,7 @@ impl Config {
         let mut context_pack_format = ContextPackFormat::AiMarkdown;
         let mut context_pack_options = ContextPackOptions::default();
         let mut select_related_path: Option<PathBuf> = None;
+        let mut tokens_path: Option<PathBuf> = None;
         let mut explain_selection = false;
         let mut session_action: Option<SessionAction> = None;
         let mut plugin_action: Option<PluginAction> = None;
@@ -346,6 +349,13 @@ impl Config {
                     }
                 }
                 "--explain-selection" => explain_selection = true,
+                "--tokens" => {
+                    if let Some(path) = args.next() {
+                        tokens_path = Some(PathBuf::from(path));
+                    } else {
+                        anyhow::bail!("--tokens requires a file path");
+                    }
+                }
                 "--session" => {
                     if let Some(action) = args.next() {
                         session_action = Some(match action.as_str() {
@@ -567,6 +577,7 @@ impl Config {
             context_pack_options,
             select_related_path,
             explain_selection,
+            tokens_path,
             session_action,
             plugin_action,
             plugin_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,10 @@ fn main() -> ExitCode {
         return run_select_related_mode(path, config.explain_selection);
     }
 
+    if let Some(ref path) = config.tokens_path {
+        return run_tokens_mode(path);
+    }
+
     if config.mcp_server {
         return run_mcp_server(&config);
     }
@@ -139,6 +143,19 @@ fn run_context_pack_mode(
 }
 
 /// Run in related-file output mode (non-interactive)
+fn run_tokens_mode(path: &std::path::Path) -> ExitCode {
+    match fileview::mcp::token::estimate_file_tokens(path) {
+        Ok(n) => {
+            println!("{}", n);
+            ExitCode::from(exit_code::SUCCESS as u8)
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::from(exit_code::ERROR as u8)
+        }
+    }
+}
+
 fn run_select_related_mode(path: &std::path::Path, explain: bool) -> ExitCode {
     if explain {
         let related = collect_related_candidates(path);

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -6,3 +6,4 @@ mod config_cli;
 mod git_ops;
 mod pick_mode;
 mod stdin_mode;
+mod tokens;

--- a/tests/e2e/tokens.rs
+++ b/tests/e2e/tokens.rs
@@ -1,0 +1,90 @@
+//! Tests for `--tokens <path>` non-interactive subcommand.
+//!
+//! Prints the estimated cl100k_base token count for the given file to stdout
+//! so AI agents and shell scripts can budget context without round-tripping
+//! through the TUI or the MCP server.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn fv() -> Command {
+    cargo_bin_cmd!("fv")
+}
+
+#[test]
+fn tokens_flag_prints_count_for_existing_file() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("hello.txt");
+    fs::write(&file, "hello world\n").unwrap();
+
+    fv().arg("--tokens")
+        .arg(&file)
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"^\d+\n$").unwrap());
+}
+
+#[test]
+fn tokens_flag_emits_positive_count_for_nonempty_file() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("doc.md");
+    fs::write(
+        &file,
+        "# Hello\n\nThis is a paragraph with enough text to tokenize.\n",
+    )
+    .unwrap();
+
+    let output = fv()
+        .arg("--tokens")
+        .arg(&file)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    let count: usize = text
+        .trim()
+        .parse()
+        .expect("stdout should be a positive integer");
+    assert!(count > 0, "expected positive token count, got {}", count);
+}
+
+#[test]
+fn tokens_flag_returns_zero_for_empty_file() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("empty.txt");
+    fs::write(&file, "").unwrap();
+
+    fv().arg("--tokens")
+        .arg(&file)
+        .assert()
+        .success()
+        .stdout("0\n");
+}
+
+#[test]
+fn tokens_flag_fails_for_missing_file() {
+    let tmp = TempDir::new().unwrap();
+    let missing = tmp.path().join("does-not-exist.txt");
+
+    fv().arg("--tokens")
+        .arg(&missing)
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("does-not-exist.txt")
+                .or(predicate::str::contains("not found")),
+        );
+}
+
+#[test]
+fn tokens_flag_requires_a_path() {
+    fv().arg("--tokens")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("requires").or(predicate::str::contains("value")));
+}


### PR DESCRIPTION
Adds a non-interactive `--tokens <path>` flag that prints the cl100k_base token estimate for the file to stdout and exits.

Lets AI agents and shell scripts budget context without spinning up the TUI or the MCP server.

```
$ fv --tokens README.md
347
```

Backed by the existing `estimate_file_tokens` helper (with the `chars / 4` fallback when the `ai` feature is off, matching the rest of the codebase).

Tests cover positive count, zero for empty file, error for missing file, and the missing-argument case.