### PR TITLE
Add --snapshot-create / --snapshot-diff for ad-hoc working-tree diffs

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -108,6 +108,10 @@ pub struct Config {
     pub explain_selection: bool,
     /// `--tokens <path>`: print cl100k_base token estimate for the file and exit.
     pub tokens_path: Option<PathBuf>,
+    /// `--snapshot-create <name>`: capture working tree manifest and exit.
+    pub snapshot_create: Option<String>,
+    /// `--snapshot-diff <name>`: print diff against named snapshot and exit.
+    pub snapshot_diff: Option<String>,
     /// Session action (save/restore/clear) - non-interactive
     pub session_action: Option<SessionAction>,
     /// Plugin command action
@@ -171,6 +175,8 @@ impl Config {
         let mut context_pack_options = ContextPackOptions::default();
         let mut select_related_path: Option<PathBuf> = None;
         let mut tokens_path: Option<PathBuf> = None;
+        let mut snapshot_create: Option<String> = None;
+        let mut snapshot_diff: Option<String> = None;
         let mut explain_selection = false;
         let mut session_action: Option<SessionAction> = None;
         let mut plugin_action: Option<PluginAction> = None;
@@ -354,6 +360,20 @@ impl Config {
                         tokens_path = Some(PathBuf::from(path));
                     } else {
                         anyhow::bail!("--tokens requires a file path");
+                    }
+                }
+                "--snapshot-create" => {
+                    if let Some(name) = args.next() {
+                        snapshot_create = Some(name);
+                    } else {
+                        anyhow::bail!("--snapshot-create requires a snapshot name");
+                    }
+                }
+                "--snapshot-diff" => {
+                    if let Some(name) = args.next() {
+                        snapshot_diff = Some(name);
+                    } else {
+                        anyhow::bail!("--snapshot-diff requires a snapshot name");
                     }
                 }
                 "--session" => {
@@ -578,6 +598,8 @@ impl Config {
             select_related_path,
             explain_selection,
             tokens_path,
+            snapshot_create,
+            snapshot_diff,
             session_action,
             plugin_action,
             plugin_path,

--- a/src/integrate/mod.rs
+++ b/src/integrate/mod.rs
@@ -20,6 +20,7 @@ pub mod pick;
 pub mod plugin_cmd;
 pub mod related;
 pub mod session;
+pub mod snapshot;
 pub mod todos;
 pub mod tree;
 

--- a/src/integrate/snapshot.rs
+++ b/src/integrate/snapshot.rs
@@ -1,0 +1,277 @@
+//! Snapshot capture and diff for AI workflows.
+//!
+//! Captures the working tree as a manifest of (path, size, mtime) tuples and
+//! lets a later invocation enumerate what was added, removed, or modified
+//! since the snapshot was taken.
+//!
+//! Designed for the case where a long-running AI session wants to know
+//! "what files have I (or the user) touched since I started", without
+//! depending on git or committing intermediate state.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+const SNAPSHOTS_SUBDIR: &str = ".fileview/snapshots";
+
+/// One file entry inside a snapshot manifest.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileEntry {
+    pub size: u64,
+    /// Unix mtime in seconds since the epoch.
+    pub mtime_secs: i64,
+    /// Sub-second precision in nanoseconds, kept separate so older formats
+    /// stay parseable if we ever drop it.
+    pub mtime_nanos: u32,
+}
+
+/// Stored snapshot manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snapshot {
+    pub name: String,
+    pub created_at_secs: i64,
+    /// `path -> entry` keyed by repo-relative path with forward slashes.
+    pub files: BTreeMap<String, FileEntry>,
+}
+
+/// One diff entry produced by [`diff_snapshot`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffOp {
+    Added,
+    Removed,
+    Modified,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffEntry {
+    pub op: DiffOp,
+    pub path: String,
+}
+
+impl DiffEntry {
+    /// Plain-text rendering: `+ path`, `- path`, `M path`.
+    pub fn render(&self) -> String {
+        let prefix = match self.op {
+            DiffOp::Added => '+',
+            DiffOp::Removed => '-',
+            DiffOp::Modified => 'M',
+        };
+        format!("{} {}", prefix, self.path)
+    }
+}
+
+/// Walk `root` and build a fresh [`Snapshot`], skipping dotfiles and the
+/// fileview metadata directory itself.
+pub fn capture_snapshot(name: &str, root: &Path) -> io::Result<Snapshot> {
+    let mut files = BTreeMap::new();
+    collect(root, root, &mut files)?;
+    Ok(Snapshot {
+        name: name.to_string(),
+        created_at_secs: now_secs(),
+        files,
+    })
+}
+
+/// Persist a snapshot to `<root>/.fileview/snapshots/<name>.json`.
+pub fn save_snapshot(root: &Path, snapshot: &Snapshot) -> io::Result<PathBuf> {
+    let dir = root.join(SNAPSHOTS_SUBDIR);
+    fs::create_dir_all(&dir)?;
+    let path = dir.join(format!("{}.json", snapshot.name));
+    let json = serde_json::to_string_pretty(snapshot).map_err(io::Error::other)?;
+    fs::write(&path, json)?;
+    Ok(path)
+}
+
+/// Load a previously saved snapshot from `<root>/.fileview/snapshots/<name>.json`.
+pub fn load_snapshot(root: &Path, name: &str) -> io::Result<Snapshot> {
+    let path = root.join(SNAPSHOTS_SUBDIR).join(format!("{}.json", name));
+    if !path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("snapshot '{}' not found at {}", name, path.display()),
+        ));
+    }
+    let text = fs::read_to_string(&path)?;
+    serde_json::from_str(&text).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+/// Compute the diff between a stored snapshot and the current state of `root`.
+pub fn diff_snapshot(root: &Path, snapshot: &Snapshot) -> io::Result<Vec<DiffEntry>> {
+    let current = capture_snapshot(&snapshot.name, root)?;
+    let mut out = Vec::new();
+
+    for (path, entry) in &snapshot.files {
+        match current.files.get(path) {
+            None => out.push(DiffEntry {
+                op: DiffOp::Removed,
+                path: path.clone(),
+            }),
+            Some(curr) if curr != entry => out.push(DiffEntry {
+                op: DiffOp::Modified,
+                path: path.clone(),
+            }),
+            _ => {}
+        }
+    }
+
+    for path in current.files.keys() {
+        if !snapshot.files.contains_key(path) {
+            out.push(DiffEntry {
+                op: DiffOp::Added,
+                path: path.clone(),
+            });
+        }
+    }
+
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(out)
+}
+
+fn collect(root: &Path, dir: &Path, out: &mut BTreeMap<String, FileEntry>) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        let metadata = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_dir() {
+            collect(root, &path, out)?;
+        } else if metadata.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+                .unwrap_or_else(|_| path.to_string_lossy().into_owned());
+            let (mtime_secs, mtime_nanos) = decompose_mtime(&metadata);
+            out.insert(
+                rel,
+                FileEntry {
+                    size: metadata.len(),
+                    mtime_secs,
+                    mtime_nanos,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn decompose_mtime(metadata: &fs::Metadata) -> (i64, u32) {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|m| m.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|d| (d.as_secs() as i64, d.subsec_nanos()))
+        .unwrap_or((0, 0))
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn touch(dir: &Path, rel: &str, contents: &str) {
+        let p = dir.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(p, contents).unwrap();
+    }
+
+    #[test]
+    fn capture_then_diff_with_no_changes_is_empty() {
+        let tmp = TempDir::new().unwrap();
+        touch(tmp.path(), "src/lib.rs", "fn lib() {}\n");
+        let snap = capture_snapshot("base", tmp.path()).unwrap();
+        let diff = diff_snapshot(tmp.path(), &snap).unwrap();
+        assert!(diff.is_empty(), "expected empty diff, got {:?}", diff);
+    }
+
+    #[test]
+    fn diff_detects_added_removed_modified() {
+        let tmp = TempDir::new().unwrap();
+        touch(tmp.path(), "keep.txt", "stable\n");
+        touch(tmp.path(), "drop.txt", "doomed\n");
+        touch(tmp.path(), "edit.txt", "before\n");
+        let snap = capture_snapshot("base", tmp.path()).unwrap();
+
+        fs::remove_file(tmp.path().join("drop.txt")).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        touch(tmp.path(), "edit.txt", "after with more bytes\n");
+        touch(tmp.path(), "new.txt", "freshly minted\n");
+
+        let diff = diff_snapshot(tmp.path(), &snap).unwrap();
+        let rendered: Vec<String> = diff.iter().map(DiffEntry::render).collect();
+        assert!(
+            rendered.contains(&"+ new.txt".to_string()),
+            "{:?}",
+            rendered
+        );
+        assert!(
+            rendered.contains(&"- drop.txt".to_string()),
+            "{:?}",
+            rendered
+        );
+        assert!(
+            rendered.contains(&"M edit.txt".to_string()),
+            "{:?}",
+            rendered
+        );
+        assert!(
+            !rendered.iter().any(|r| r.contains("keep.txt")),
+            "{:?}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn capture_skips_dotfiles_and_dot_dirs() {
+        let tmp = TempDir::new().unwrap();
+        touch(tmp.path(), "src/lib.rs", "fn lib() {}\n");
+        touch(tmp.path(), ".hidden", "x\n");
+        touch(tmp.path(), ".cache/index", "x\n");
+        let snap = capture_snapshot("base", tmp.path()).unwrap();
+        assert!(snap.files.contains_key("src/lib.rs"));
+        assert!(!snap.files.iter().any(|(p, _)| p.contains(".hidden")));
+        assert!(!snap.files.iter().any(|(p, _)| p.contains(".cache")));
+    }
+
+    #[test]
+    fn save_then_load_roundtrips() {
+        let tmp = TempDir::new().unwrap();
+        touch(tmp.path(), "src/lib.rs", "fn lib() {}\n");
+        let snap = capture_snapshot("foo", tmp.path()).unwrap();
+        let path = save_snapshot(tmp.path(), &snap).unwrap();
+        assert!(path.exists());
+        let loaded = load_snapshot(tmp.path(), "foo").unwrap();
+        assert_eq!(loaded.name, snap.name);
+        assert_eq!(loaded.files, snap.files);
+    }
+
+    #[test]
+    fn load_missing_snapshot_returns_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let err = load_snapshot(tmp.path(), "nope").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,14 @@ fn main() -> ExitCode {
         return run_tokens_mode(path);
     }
 
+    if let Some(ref name) = config.snapshot_create {
+        return run_snapshot_create_mode(name);
+    }
+
+    if let Some(ref name) = config.snapshot_diff {
+        return run_snapshot_diff_mode(name);
+    }
+
     if config.mcp_server {
         return run_mcp_server(&config);
     }
@@ -147,6 +155,57 @@ fn run_tokens_mode(path: &std::path::Path) -> ExitCode {
     match fileview::mcp::token::estimate_file_tokens(path) {
         Ok(n) => {
             println!("{}", n);
+            ExitCode::from(exit_code::SUCCESS as u8)
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::from(exit_code::ERROR as u8)
+        }
+    }
+}
+
+fn run_snapshot_create_mode(name: &str) -> ExitCode {
+    use fileview::integrate::snapshot::{capture_snapshot, save_snapshot};
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return ExitCode::from(exit_code::ERROR as u8);
+        }
+    };
+    match capture_snapshot(name, &cwd).and_then(|s| save_snapshot(&cwd, &s)) {
+        Ok(path) => {
+            eprintln!("Snapshot saved to {}", path.display());
+            ExitCode::from(exit_code::SUCCESS as u8)
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::from(exit_code::ERROR as u8)
+        }
+    }
+}
+
+fn run_snapshot_diff_mode(name: &str) -> ExitCode {
+    use fileview::integrate::snapshot::{diff_snapshot, load_snapshot};
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return ExitCode::from(exit_code::ERROR as u8);
+        }
+    };
+    let snap = match load_snapshot(&cwd, name) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return ExitCode::from(exit_code::ERROR as u8);
+        }
+    };
+    match diff_snapshot(&cwd, &snap) {
+        Ok(entries) => {
+            for entry in entries {
+                println!("{}", entry.render());
+            }
             ExitCode::from(exit_code::SUCCESS as u8)
         }
         Err(e) => {

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -5,5 +5,6 @@ mod cli_basic;
 mod config_cli;
 mod git_ops;
 mod pick_mode;
+mod snapshot;
 mod stdin_mode;
 mod tokens;

--- a/tests/e2e/snapshot.rs
+++ b/tests/e2e/snapshot.rs
@@ -1,0 +1,164 @@
+//! Tests for `--snapshot-create <name>` / `--snapshot-diff <name>` subcommands.
+//!
+//! Lets an AI session capture the working tree at a point in time and ask
+//! "what changed since then" without leaning on git. Useful when the user
+//! hasn't committed yet, or for tracking ad-hoc experiments.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn fv() -> Command {
+    cargo_bin_cmd!("fv")
+}
+
+fn write_file(dir: &Path, rel: &str, contents: &str) {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+#[test]
+fn snapshot_create_in_empty_dir_succeeds() {
+    let tmp = TempDir::new().unwrap();
+    fv().arg("--snapshot-create")
+        .arg("alpha")
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    assert!(
+        tmp.path().join(".fileview/snapshots/alpha.json").exists(),
+        "snapshot file should be created"
+    );
+}
+
+#[test]
+fn snapshot_create_requires_a_name() {
+    let tmp = TempDir::new().unwrap();
+    fv().arg("--snapshot-create")
+        .current_dir(tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("requires").or(predicate::str::contains("value")));
+}
+
+#[test]
+fn snapshot_diff_with_no_changes_outputs_nothing() {
+    let tmp = TempDir::new().unwrap();
+    write_file(tmp.path(), "src/lib.rs", "fn lib() {}\n");
+    fv().arg("--snapshot-create")
+        .arg("base")
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    fv().arg("--snapshot-diff")
+        .arg("base")
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn snapshot_diff_shows_added_file() {
+    let tmp = TempDir::new().unwrap();
+    write_file(tmp.path(), "src/lib.rs", "fn lib() {}\n");
+    fv().arg("--snapshot-create")
+        .arg("base")
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    write_file(tmp.path(), "src/new.rs", "fn new() {}\n");
+
+    fv().arg("--snapshot-diff")
+        .arg("base")
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("+ src/new.rs"));
+}
+
+#[test]
+fn snapshot_diff_shows_removed_file() {
+    let tmp = TempDir::new().unwrap();
+    write_file(tmp.path(), "keep.txt", "stays\n");
+    write_file(tmp.path(), "drop.txt", "will be deleted\n");
+    fv().arg("--snapshot-create")
+        .arg("base")
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    fs::remove_file(tmp.path().join("drop.txt")).unwrap();
+
+    fv().arg("--snapshot-diff")
+        .arg("base")
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("- drop.txt"))
+        .stdout(predicate::str::contains("+ ").not())
+        .stdout(predicate::str::contains("M ").not());
+}
+
+#[test]
+fn snapshot_diff_shows_modified_file() {
+    let tmp = TempDir::new().unwrap();
+    write_file(tmp.path(), "doc.md", "first version\n");
+    fv().arg("--snapshot-create")
+        .arg("base")
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Sleep briefly so mtime resolution catches the change on all platforms.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    write_file(tmp.path(), "doc.md", "second version with more content\n");
+
+    fv().arg("--snapshot-diff")
+        .arg("base")
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("M doc.md"));
+}
+
+#[test]
+fn snapshot_diff_skips_dotfiles_and_dot_dirs() {
+    let tmp = TempDir::new().unwrap();
+    write_file(tmp.path(), "src/lib.rs", "fn lib() {}\n");
+    fv().arg("--snapshot-create")
+        .arg("base")
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    write_file(tmp.path(), ".hidden", "x\n");
+    write_file(tmp.path(), ".cache/index", "x\n");
+
+    fv().arg("--snapshot-diff")
+        .arg("base")
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".hidden").not())
+        .stdout(predicate::str::contains(".cache").not());
+}
+
+#[test]
+fn snapshot_diff_for_missing_snapshot_fails() {
+    let tmp = TempDir::new().unwrap();
+    fv().arg("--snapshot-diff")
+        .arg("nonexistent")
+        .current_dir(tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("nonexistent").or(predicate::str::contains("not found")));
+}


### PR DESCRIPTION
Adds two non-interactive flags:

- `fv --snapshot-create <name>` captures a manifest (path, size, mtime) of the working tree and stores it at `.fileview/snapshots/<name>.json`.
- `fv --snapshot-diff <name>` re-walks the tree and prints `+ added` / `- removed` / `M modified` lines for every change since the snapshot.

Solves the "what have I (or the AI) touched since this session started" question without requiring a git commit. Useful when an agent wants to know mid-flight what state things are in, or when reviewing the impact of an exploratory experiment.

Skips dotfiles and dot-directories so `.git/`, `.fileview/` itself, `.cache/` etc. don't bloat the manifest. Symlinks are skipped too.

Covered by 5 unit tests in `src/integrate/snapshot.rs` plus 8 e2e tests in `tests/e2e/snapshot.rs`.