### PR TITLE
Add --watch <path> for block-until-changed detection

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -112,6 +112,10 @@ pub struct Config {
     pub snapshot_create: Option<String>,
     /// `--snapshot-diff <name>`: print diff against named snapshot and exit.
     pub snapshot_diff: Option<String>,
+    /// `--watch <path>`: block until path is modified, then print and exit.
+    pub watch_path: Option<PathBuf>,
+    /// `--watch-timeout-secs <n>`: optional timeout for --watch.
+    pub watch_timeout_secs: Option<u64>,
     /// Session action (save/restore/clear) - non-interactive
     pub session_action: Option<SessionAction>,
     /// Plugin command action
@@ -177,6 +181,8 @@ impl Config {
         let mut tokens_path: Option<PathBuf> = None;
         let mut snapshot_create: Option<String> = None;
         let mut snapshot_diff: Option<String> = None;
+        let mut watch_path: Option<PathBuf> = None;
+        let mut watch_timeout_secs: Option<u64> = None;
         let mut explain_selection = false;
         let mut session_action: Option<SessionAction> = None;
         let mut plugin_action: Option<PluginAction> = None;
@@ -374,6 +380,25 @@ impl Config {
                         snapshot_diff = Some(name);
                     } else {
                         anyhow::bail!("--snapshot-diff requires a snapshot name");
+                    }
+                }
+                "--watch" => {
+                    if let Some(path) = args.next() {
+                        watch_path = Some(PathBuf::from(path));
+                    } else {
+                        anyhow::bail!("--watch requires a file path");
+                    }
+                }
+                "--watch-timeout-secs" => {
+                    if let Some(secs_str) = args.next() {
+                        watch_timeout_secs = Some(secs_str.parse().map_err(|_| {
+                            anyhow::anyhow!(
+                                "--watch-timeout-secs requires a non-negative integer, got '{}'",
+                                secs_str
+                            )
+                        })?);
+                    } else {
+                        anyhow::bail!("--watch-timeout-secs requires a value");
                     }
                 }
                 "--session" => {
@@ -600,6 +625,8 @@ impl Config {
             tokens_path,
             snapshot_create,
             snapshot_diff,
+            watch_path,
+            watch_timeout_secs,
             session_action,
             plugin_action,
             plugin_path,

--- a/src/integrate/mod.rs
+++ b/src/integrate/mod.rs
@@ -23,6 +23,7 @@ pub mod session;
 pub mod snapshot;
 pub mod todos;
 pub mod tree;
+pub mod watch;
 
 pub use ai_ignore::{synthesize as synthesize_ai_ignore, AiIgnoreAgent, SynthesisOutcome};
 pub use benchmark::run_ai_benchmark;

--- a/src/integrate/watch.rs
+++ b/src/integrate/watch.rs
@@ -1,0 +1,153 @@
+//! Block-until-changed file watcher for AI workflows.
+//!
+//! Lets a script (or an AI agent via shell) wait for one or more files to be
+//! modified externally, then return the changed paths. Used to detect stale
+//! reads in long-running sessions: the AI takes a snapshot, runs analysis,
+//! then asks `fv --watch <file> --timeout-secs 1` right before applying a
+//! patch. If the file moved underneath, the watch returns and the agent
+//! refreshes its read instead of overwriting fresh edits.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{channel, RecvTimeoutError};
+use std::time::Duration;
+
+use notify_debouncer_mini::{new_debouncer, notify::RecursiveMode};
+
+/// Outcome of a watch call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WatchOutcome {
+    /// At least one watched path changed before the timeout.
+    Changed(Vec<PathBuf>),
+    /// Timeout elapsed with no change observed.
+    Timeout,
+}
+
+/// Block until any of `paths` is modified, or until `timeout` elapses.
+///
+/// `None` timeout means wait forever. The debouncer collapses bursts of
+/// filesystem events so a single editor write does not produce multiple
+/// notifications.
+pub fn watch_until_change(
+    paths: &[PathBuf],
+    timeout: Option<Duration>,
+) -> io::Result<WatchOutcome> {
+    if paths.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "watch requires at least one path",
+        ));
+    }
+    for p in paths {
+        if !p.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("watch target not found: {}", p.display()),
+            ));
+        }
+    }
+
+    let (tx, rx) = channel();
+    let mut debouncer = new_debouncer(Duration::from_millis(100), move |res| {
+        let _ = tx.send(res);
+    })
+    .map_err(io::Error::other)?;
+
+    for p in paths {
+        let mode = if p.is_dir() {
+            RecursiveMode::Recursive
+        } else {
+            RecursiveMode::NonRecursive
+        };
+        debouncer
+            .watcher()
+            .watch(p, mode)
+            .map_err(io::Error::other)?;
+    }
+
+    let recv_result = match timeout {
+        Some(d) => rx.recv_timeout(d),
+        None => rx.recv().map_err(|_| RecvTimeoutError::Disconnected),
+    };
+
+    match recv_result {
+        Ok(Ok(events)) => {
+            let mut changed: Vec<PathBuf> = events.into_iter().map(|e| e.path).collect();
+            changed.sort();
+            changed.dedup();
+            Ok(WatchOutcome::Changed(changed))
+        }
+        Ok(Err(err)) => Err(io::Error::other(err.to_string())),
+        Err(RecvTimeoutError::Timeout) => Ok(WatchOutcome::Timeout),
+        Err(RecvTimeoutError::Disconnected) => Err(io::Error::other("watcher channel closed")),
+    }
+}
+
+/// Convenience wrapper for the common single-path case.
+pub fn watch_one(path: &Path, timeout: Option<Duration>) -> io::Result<WatchOutcome> {
+    watch_until_change(&[path.to_path_buf()], timeout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::mpsc;
+    use std::thread;
+    use tempfile::TempDir;
+
+    #[test]
+    fn timeout_with_no_change_returns_timeout() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("idle.txt");
+        fs::write(&path, "initial\n").unwrap();
+
+        let outcome = watch_one(&path, Some(Duration::from_millis(300))).unwrap();
+        assert_eq!(outcome, WatchOutcome::Timeout);
+    }
+
+    #[test]
+    fn modification_during_watch_returns_changed() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("active.txt");
+        fs::write(&path, "initial\n").unwrap();
+
+        let writer_path = path.clone();
+        let (ready_tx, ready_rx) = mpsc::channel::<()>();
+        let writer = thread::spawn(move || {
+            // Wait until the main thread signals the watcher is armed,
+            // then repeatedly write so the watcher has multiple chances
+            // to observe an event even if backend setup is slow.
+            let _ = ready_rx.recv();
+            for i in 0..20 {
+                thread::sleep(Duration::from_millis(150));
+                let _ = fs::write(&writer_path, format!("write {}\n", i));
+            }
+        });
+
+        ready_tx.send(()).unwrap();
+        let outcome = watch_one(&path, Some(Duration::from_secs(10))).unwrap();
+        drop(writer); // detach; writer will finish on its own
+
+        match outcome {
+            WatchOutcome::Changed(paths) => {
+                assert!(!paths.is_empty(), "expected at least one changed path");
+            }
+            WatchOutcome::Timeout => panic!("expected Changed, got Timeout"),
+        }
+    }
+
+    #[test]
+    fn empty_paths_is_rejected() {
+        let err = watch_until_change(&[], Some(Duration::from_millis(100))).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn missing_path_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("nope.txt");
+        let err = watch_one(&missing, Some(Duration::from_millis(100))).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/src/integrate/watch.rs
+++ b/src/integrate/watch.rs
@@ -65,6 +65,18 @@ pub fn watch_until_change(
             .map_err(io::Error::other)?;
     }
 
+    // Drain any events delivered for activity that pre-dates the watch
+    // (notably macOS FSEvents replays of the file's own creation moments
+    // before this call). 250 ms is comfortably larger than the debouncer's
+    // 100 ms window and stays well under any practical user timeout.
+    let drain_until = std::time::Instant::now() + Duration::from_millis(250);
+    while let Some(remaining) = drain_until.checked_duration_since(std::time::Instant::now()) {
+        match rx.recv_timeout(remaining) {
+            Ok(_) => continue,
+            Err(_) => break,
+        }
+    }
+
     let recv_result = match timeout {
         Some(d) => rx.recv_timeout(d),
         None => rx.recv().map_err(|_| RecvTimeoutError::Disconnected),
@@ -102,7 +114,9 @@ mod tests {
         let path = tmp.path().join("idle.txt");
         fs::write(&path, "initial\n").unwrap();
 
-        let outcome = watch_one(&path, Some(Duration::from_millis(300))).unwrap();
+        // Past the 250 ms drain window with margin so the timeout itself,
+        // not setup latency, is what the test is exercising.
+        let outcome = watch_one(&path, Some(Duration::from_millis(800))).unwrap();
         assert_eq!(outcome, WatchOutcome::Timeout);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,10 @@ fn main() -> ExitCode {
         return run_snapshot_diff_mode(name);
     }
 
+    if let Some(ref path) = config.watch_path {
+        return run_watch_mode(path, config.watch_timeout_secs);
+    }
+
     if config.mcp_server {
         return run_mcp_server(&config);
     }
@@ -177,6 +181,27 @@ fn run_snapshot_create_mode(name: &str) -> ExitCode {
         Ok(path) => {
             eprintln!("Snapshot saved to {}", path.display());
             ExitCode::from(exit_code::SUCCESS as u8)
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::from(exit_code::ERROR as u8)
+        }
+    }
+}
+
+fn run_watch_mode(path: &std::path::Path, timeout_secs: Option<u64>) -> ExitCode {
+    use fileview::integrate::watch::{watch_one, WatchOutcome};
+    let timeout = timeout_secs.map(std::time::Duration::from_secs);
+    match watch_one(path, timeout) {
+        Ok(WatchOutcome::Changed(paths)) => {
+            for p in paths {
+                println!("{}", p.display());
+            }
+            ExitCode::from(exit_code::SUCCESS as u8)
+        }
+        Ok(WatchOutcome::Timeout) => {
+            eprintln!("timeout: no change observed");
+            ExitCode::from(exit_code::CANCELLED as u8)
         }
         Err(e) => {
             eprintln!("Error: {}", e);

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -8,3 +8,4 @@ mod pick_mode;
 mod snapshot;
 mod stdin_mode;
 mod tokens;
+mod watch;

--- a/tests/e2e/watch.rs
+++ b/tests/e2e/watch.rs
@@ -1,0 +1,69 @@
+//! Tests for `--watch <path> [--watch-timeout-secs N]` subcommand.
+//!
+//! Blocks until the path is modified externally, then prints the changed
+//! path and exits. With a timeout, exits with the CANCELLED code when
+//! nothing happens. Lets AI sessions detect stale reads before applying
+//! patches.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn fv() -> Command {
+    cargo_bin_cmd!("fv")
+}
+
+#[test]
+fn watch_with_short_timeout_and_no_change_exits_cancelled() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("idle.txt");
+    fs::write(&file, "stable\n").unwrap();
+
+    // Give macOS FSEvents a moment to settle so the watch does not pick
+    // up the file-creation event itself as a "change".
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    fv().arg("--watch")
+        .arg(&file)
+        .arg("--watch-timeout-secs")
+        .arg("1")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("timeout").or(predicate::str::contains("no change")));
+}
+
+#[test]
+fn watch_requires_a_path() {
+    fv().arg("--watch")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("requires").or(predicate::str::contains("value")));
+}
+
+#[test]
+fn watch_missing_file_returns_runtime_error() {
+    let tmp = TempDir::new().unwrap();
+    let missing = tmp.path().join("nope.txt");
+    fv().arg("--watch")
+        .arg(&missing)
+        .arg("--watch-timeout-secs")
+        .arg("1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("nope.txt").or(predicate::str::contains("not found")));
+}
+
+#[test]
+fn watch_timeout_secs_requires_a_value() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("x.txt");
+    fs::write(&file, "x").unwrap();
+    fv().arg("--watch")
+        .arg(&file)
+        .arg("--watch-timeout-secs")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("requires").or(predicate::str::contains("value")));
+}


### PR DESCRIPTION
Adds a non-interactive `fv --watch <path> [--watch-timeout-secs N]` flag that blocks until the path is modified externally, prints the changed paths, and exits.

Lets an AI agent or shell script detect stale reads in long-running sessions. Typical pattern: agent takes a snapshot, runs analysis, then calls `fv --watch <file> --watch-timeout-secs 1` right before applying a patch. If the file moved underneath, watch returns and the agent refreshes its read instead of overwriting fresh edits.

Exit codes:
- `0`: file changed (paths printed to stdout)
- `1`: timeout elapsed with no change
- `2`: runtime error (missing target, watcher init failed)
- `3`: invalid arguments

Uses the existing `notify_debouncer_mini` dependency. Watches a single file with `NonRecursive` mode or a directory with `Recursive`.

Covered by 4 unit tests in `src/integrate/watch.rs` and 4 e2e tests in `tests/e2e/watch.rs`.