### PR TITLE
Release 2.7.0: document --tokens / --snapshot / --watch flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2026-05-16
+
+Three small non-interactive flags that let AI agents and shell scripts
+talk to fileview without spinning up the TUI or the MCP server.
+
+### Added
+
+- `fv --tokens <path>` prints a cl100k_base token estimate for the file
+  to stdout and exits. Useful for budgeting context before assembling a
+  prompt. Falls back to the `chars / 4` heuristic when the `ai` feature
+  is off, matching the rest of the codebase.
+- `fv --snapshot-create <name>` captures a working-tree manifest
+  (path / size / mtime, dotfiles skipped) to
+  `.fileview/snapshots/<name>.json`. `fv --snapshot-diff <name>` then
+  prints `+ added`, `- removed`, and `M modified` lines for every change
+  since the snapshot. Lets a long-running agent answer "what have I
+  touched since this session started" without committing intermediate
+  state.
+- `fv --watch <path> [--watch-timeout-secs N]` blocks until the path is
+  modified externally, prints the changed paths, and exits. Exit code
+  `0` on change, `1` on timeout. Drains the initial filesystem-event
+  burst (notably macOS FSEvents replays) before waiting so a freshly
+  created file does not register as an immediate "change".
+
+### Internal
+
+- New module `integrate::snapshot` with five unit tests covering
+  capture, diff, save/load round-trip, dotfile skipping, and missing
+  snapshots.
+- New module `integrate::watch` with four unit tests covering the
+  empty-paths guard, the missing-path guard, the timeout path, and the
+  modification path.
+- E2E coverage: 5 tests for `--tokens`, 8 for snapshot, 4 for watch
+  (21 new tests in `tests/e2e/`).
+
 ## [2.6.0] - 2026-05-11
 
 A focused release on AI-driven workflows and slim builds. Adds eight

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,23 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に基づいており、
 [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
+## [2.7.0] - 2026-05-16
+
+AI agent や shell スクリプトから TUI/MCP server を介さず fileview を呼べる
+非対話型フラグを 3 つ追加。`CHANGELOG.md` の英語版が一次情報。
+
+### 追加
+- `fv --tokens <path>` — ファイルの cl100k_base token 推定値を stdout に出力
+- `fv --snapshot-create <name>` / `fv --snapshot-diff <name>` — 作業ツリーの
+  manifest (path/size/mtime) を `.fileview/snapshots/<name>.json` に保存し、
+  後から `+ added / - removed / M modified` の差分を表示
+- `fv --watch <path> [--watch-timeout-secs N]` — 指定ファイルが変更されるまで
+  block、変更時に path を print して exit 0、timeout 時 exit 1
+
+### 内部
+- `integrate::snapshot` / `integrate::watch` モジュール新設、ユニットテスト
+  9 件 + e2e テスト 12 件、合計 21 件追加
+
 ## [2.6.0] - 2026-05-11
 
 AI 駆動ワークフローと slim ビルドに焦点を当てたリリース。8 つの新機能と

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 rust-version = "1.90.0"  # MSRV - Minimum Supported Rust Version
 description = "A fast, keyboard-driven TUI file browser with previews and git"

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ Your terminal is auto-detected:
 
 See [docs/KEYBINDINGS.md](docs/KEYBINDINGS.md) for the full list.
 
+## One-shot helpers for AI workflows
+
+A few non-interactive flags for use from scripts and AI agents:
+
+```bash
+fv --tokens README.md            # cl100k_base token estimate (one integer to stdout)
+fv --snapshot-create base        # capture working tree manifest to .fileview/snapshots/
+fv --snapshot-diff base          # + added / - removed / M modified since snapshot
+fv --watch path/to/file          # block until the file changes, print path, exit
+fv --watch path/to/file --watch-timeout-secs 5
+```
+
+See [docs/CLAUDE_CODE.md](docs/CLAUDE_CODE.md) for the full list.
+
 ## Claude Code Integration
 
 FileView includes an MCP server for Claude Code (`fv --mcp-server`).

--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -16,6 +16,12 @@ selected=$(fv --select-mode --multi)
 
 # Run as MCP server
 fv --mcp-server
+
+# One-shot helpers for AI scripting
+fv --tokens src/main.rs                  # token estimate
+fv --snapshot-create base                # capture state
+fv --snapshot-diff base                  # changes since snapshot
+fv --watch src/lib.rs --watch-timeout-secs 5   # block until file changes
 ```
 
 ## CLI Options (AI-related)
@@ -33,6 +39,11 @@ fv --mcp-server
 | `--select-related F` | Output related file paths |
 | `--explain-selection` | Include score/reasons for `--select-related` |
 | `--resume-ai-session [NAME]` | Restore AI session metadata (default: `ai`) |
+| `--tokens F` | Print cl100k_base token estimate for file `F` to stdout |
+| `--snapshot-create N` | Capture working-tree manifest to `.fileview/snapshots/N.json` |
+| `--snapshot-diff N` | Print `+/-/M` lines for changes since snapshot `N` |
+| `--watch F` | Block until file `F` is modified, then print and exit (use with `--watch-timeout-secs`) |
+| `--watch-timeout-secs S` | Optional timeout for `--watch`; exit code 1 on timeout |
 | `benchmark ai` | Run AI workflow benchmarks |
 | `init claude` | Add fileview MCP entry to Claude config |
 


### PR DESCRIPTION
Bumps to 2.7.0 and documents the three flags added in #204, #205, #206.

- README.md: new "One-shot helpers for AI workflows" section above Claude Code Integration with a usage block.
- docs/CLAUDE_CODE.md: adds the four new flags to the AI-related CLI options table and to the Quick Start snippet.
- CHANGELOG.md / CHANGELOG_ja.md: 2.7.0 section describing all three features and the test coverage delta.

Ready for crates.io publish after merge.