### PR TITLE
Fix awk in release.yml so changelog section is extracted correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,11 +89,19 @@ jobs:
         run: |
           # Extract version from tag
           VERSION="${{ github.ref_name }}"
+          VER_NUM="${VERSION#v}"
 
-          # Try to extract changelog entry for this version
+          # Extract the changelog section for this version.
+          # State-machine scan: turn on when we see the matching header,
+          # turn off (and exit) on the next "## " header. The previous
+          # range-based pattern collapsed to one line because the start
+          # header (e.g. "## [2.7.0]") also matched the end pattern.
           if [ -f CHANGELOG.md ]; then
-            # Extract the section for this version
-            NOTES=$(awk "/^## \[${VERSION#v}\]|^## ${VERSION}/,/^## \[|^## v/" CHANGELOG.md | head -n -1 | tail -n +2)
+            NOTES=$(awk -v ver="$VER_NUM" '
+              $0 ~ "^## \\[" ver "\\]" || $0 ~ "^## " ver "( |$)" { in_section = 1; next }
+              in_section && /^## / { exit }
+              in_section { print }
+            ' CHANGELOG.md)
             if [ -z "$NOTES" ]; then
               NOTES="Release ${VERSION}"
             fi


### PR DESCRIPTION
v2.7.0's release auto-notes only contained `Release v2.7.0` (the fallback) because the awk range pattern collapsed on the start line.

Original:
```bash
awk "/^## \[${VERSION#v}\]|^## ${VERSION}/,/^## \[|^## v/" CHANGELOG.md
```

The end pattern `/^## \[/` also matches the start line `## [2.7.0]`, so awk closes the range immediately and returns one line. `head -n -1 | tail -n +2` then strips that line and yields empty output, falling through to the `Release ${VERSION}` fallback.

Replaced with a state-machine scan that explicitly skips the header line, prints the body, and exits on the next `## ` header. Verified locally against both `2.6.0` (73 lines extracted) and `2.7.0` (full section).