### PR TITLE
Release 2.7.1: internal refactor + release.yml fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] - 2026-05-16
+
+Pure-refactor and release-tooling release. No behaviour, API, dependency,
+binary-size, or feature changes.
+
+### Internal
+
+- Split `src/handler/action/tests.rs` (2928 LOC, one file) into a
+  `tests/` directory with one file per pre-existing logical section
+  (`basic`, `state_transition`, `sequence`, `edge_cases`, `focus`,
+  `scroll_bounds`) plus a `mod.rs` that owns the shared helpers and the
+  `call_handle_action!` macro.
+- Split `src/render/status.rs` (1644 LOC, one file) into a `status/`
+  directory: `bar.rs` (density variants + budget segment), `format.rs`
+  (file metadata + size/time formatters), `popup.rs` (input/confirm/mini
+  popups), `help.rs` (help overlay), `todos.rs` (TODO/FIXME popup), with
+  `mod.rs` re-exporting the existing public renderers.
+
+### Fixed
+
+- `release.yml`: the awk pattern range used to extract the per-version
+  changelog section was collapsing to one line because the start header
+  also matched the end pattern. Replaced with a state-machine scan so
+  future tag pushes get the right notes auto-attached to the GitHub
+  Release.
+
 ## [2.7.0] - 2026-05-16
 
 Three small non-interactive flags that let AI agents and shell scripts

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,22 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に基づいており、
 [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
+## [2.7.1] - 2026-05-16
+
+純粋なリファクタとリリースツール修正のみ。挙動・API・依存・バイナリサイズ・
+feature の変更はなし。`CHANGELOG.md` の英語版が一次情報。
+
+### 内部
+- `src/handler/action/tests.rs` (2928 LOC) を `tests/` ディレクトリに
+  6 ファイル分割 (basic / state_transition / sequence / edge_cases /
+  focus / scroll_bounds + 共有ヘルパー入りの mod.rs)
+- `src/render/status.rs` (1644 LOC) を `status/` ディレクトリに
+  6 ファイル分割 (bar / format / popup / help / todos / mod)
+
+### 修正
+- `release.yml` の awk が range pattern の重複で section 抽出に失敗していた
+  問題を state-machine 方式に書き直して修正
+
 ## [2.7.0] - 2026-05-16
 
 AI agent や shell スクリプトから TUI/MCP server を介さず fileview を呼べる

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.7.0"
+version = "2.7.1"
 edition = "2021"
 rust-version = "1.90.0"  # MSRV - Minimum Supported Rust Version
 description = "A fast, keyboard-driven TUI file browser with previews and git"


### PR DESCRIPTION
Patch bump for #208, #209, #210. No behaviour / API / dependency / binary-size / feature changes.

- #209 split `handler/action/tests.rs` (2928 LOC) into a `tests/` directory, one file per section
- #210 split `render/status.rs` (1644 LOC) into a `status/` directory (bar / format / popup / help / todos)
- #208 fixed the awk in `release.yml` so future tag pushes get the right changelog section attached to the GitHub Release

Ready for crates.io publish after merge.