### PR TITLE
Ignore RUSTSEC-2026-0097 in cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,7 +3,12 @@
 # - syntect transitively pulls unmaintained crates (bincode 1.x / yaml-rust 0.4.x)
 # - these are currently used for syntax highlighting only (non-network, local parsing path)
 # - tracked for replacement/upgrade in dependency hardening backlog
+# - RUSTSEC-2026-0097: rand soundness bug only triggers when a custom log
+#   crate logger calls `rand::rng()` and reseeds inside the callback.
+#   fileview does not depend on the `log` crate and ships no custom
+#   logger, so none of the trigger conditions apply.
 ignore = [
   "RUSTSEC-2025-0141", # bincode (via syntect)
   "RUSTSEC-2024-0320", # yaml-rust (via syntect)
+  "RUSTSEC-2026-0097", # rand unsoundness, conditions not reachable from fileview
 ]


### PR DESCRIPTION
The advisory describes a soundness bug in `rand` (versions 0.8.5 and 0.9.2 in our dependency tree) that triggers only when:

1. The `log` + `thread_rng` features are enabled.
2. A custom `log` crate logger is defined.
3. The custom logger calls `rand::rng()` and a `TryRng` method.
4. The `ThreadRng` reseeds inside that logger call (every 64 KB).
5. Trace-level logging is enabled.

fileview does not depend on the `log` crate and ships no custom logger, so none of these conditions are reachable. Closes the recurring weekly audit issue without adding a code change.

Closes #182, closes #183.