### PR TITLE
Release 2.7.3: dependency bumps and RUSTSEC ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.3] - 2026-05-16
+
+Dependency bumps and security-audit policy update. No source-code or
+behaviour changes.
+
+### Changed
+
+- Dependabot bumped the `rust-minor-patch` group: `toml` 1.0.7 →
+  1.1.2, `zip` 8.3.1 → 8.6.0, `trash` 5.2.5 → 5.2.6, `libc` 0.2.182 →
+  0.2.186, `assert_cmd` 2.2.0 → 2.2.2 (#203).
+- Added RUSTSEC-2026-0097 (rand soundness bug, triggered only by
+  custom `log` crate loggers calling `rand::rng()` mid-callback) to
+  the `cargo audit` ignore list. None of the trigger conditions are
+  reachable from fileview, which has no `log` dependency and ships no
+  custom logger (#216, closes #182, closes #183).
+
 ## [2.7.2] - 2026-05-16
 
 Documentation and repository tidy-up. No source code changes; no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "2.7.2"
+version = "2.7.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.7.2"
+version = "2.7.3"
 edition = "2021"
 rust-version = "1.90.0"  # MSRV - Minimum Supported Rust Version
 description = "A fast, keyboard-driven TUI file browser with previews and git"


### PR DESCRIPTION
Patch bump for #203 + #216.

- #203 bumped 5 internal crates (toml, zip, trash, libc, assert_cmd) via Dependabot
- #216 added `RUSTSEC-2026-0097` to `.cargo/audit.toml`; the rand soundness bug's trigger conditions (custom `log` logger calling `rand::rng()` mid-reseed) are not reachable from fileview

No code or behaviour change. Ready for crates.io publish after merge.