### PR TITLE
Security hardening: MCP argument injection, sensitive-path guards, and safe file ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Security hardening across the MCP server, interactive file operations, the
+external-tool integrations, and the documentation. No change to the default
+keyboard-driven browsing experience.
+
+### Security
+
+- MCP `write_file` and `delete_file` now refuse sensitive paths (`.git/hooks`,
+  `.git/config`, `.env`, credential files), closing a path where an AI client
+  could plant a git hook that executes on the next git command.
+- MCP `search_code`, `get_references`, `get_diagnostics`, `run_test`, and
+  `run_lint` no longer let a caller-supplied pattern, symbol, path, or filter
+  be interpreted as an option flag (argument injection such as `rg --pre` or
+  `eslint --rulesdir`). A `--` separator, validated canonical paths, and a
+  leading-dash rejection are applied.
+- Interactive create, rename, and bulk-rename reject names containing a path
+  separator or `..`, so input can no longer escape the target directory.
+- Cut/paste (move) now allocates a unique destination name instead of silently
+  overwriting an existing same-named file.
+- `ffprobe`/`ffmpeg` preview calls guard against a leading-dash filename being
+  parsed as an option.
+- The context pack skips sensitive files (e.g. `.env`) even when explicitly
+  selected, so secrets are not embedded.
+
+### Changed
+
+- `validate_path` compares against the canonicalized root, so a root reached
+  through a symlink no longer rejects legitimate in-root paths.
+- Config, session, snapshot, and AI-activity files are read with a size cap as
+  defence-in-depth against an oversized file exhausting memory during parsing.
+- Archive-entry and MCP entry-name truncation slice on UTF-8 boundaries,
+  avoiding a panic on multibyte names.
+- Documentation now states accurately that Lua plugins are trusted, unsandboxed
+  code with full system access, and documents the MCP server's trust model.
+
 ## [2.7.3] - 2026-05-16
 
 Dependency bumps and security-audit policy update. No source-code or

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -145,9 +145,32 @@ The `register_previewer` function supports glob patterns:
 | `test*` | `test.txt`, `testing.md` |
 | `*test*` | `my_test_file`, `testing` |
 
+## Security
+
+Plugins are **not** sandboxed. They run as fully trusted user code in a
+standard Lua 5.4 runtime with the complete standard library available,
+including `os.execute`, `io.*`, `require`, and `package.loadlib`. A plugin can
+therefore run arbitrary commands, read and write any file your account can
+access, and make network connections. This is equivalent to running a shell
+script you wrote yourself.
+
+Consequences to be aware of:
+
+- `~/.config/fileview/plugins/init.lua` is loaded and executed automatically on
+  every startup. Anything able to write that file gains code execution the next
+  time you launch FileView, so treat the plugin directory like any other
+  executable on your `PATH`.
+- Only install plugin code you have read and trust. Do not paste plugins from
+  untrusted sources.
+- When a plugin builds a shell command from a file path, quote it. For example
+  `os.execute("git add " .. file)` is unsafe for a file named `; rm -rf ~`;
+  prefer escaping the path or avoiding the shell.
+
+To run without any plugin code, build with the `lua` feature disabled
+(`cargo build --no-default-features --features ai,archive,clipboard`).
+
 ## Notes
 
-- Plugins run in a sandboxed Lua 5.4 environment
 - Errors in plugins are caught and displayed as notifications
 - Multiple handlers can be registered for the same event
 - Previewers return strings that are displayed in the preview panel

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,8 +7,35 @@ fileview (fv) is a file browser that runs with the user's permissions.
 ## Security Model
 
 - Runs as the current user with their file permissions
-- No privilege escalation or network operations
-- File operations affect user's own filesystem
+- No privilege escalation
+- File operations affect the user's own filesystem
+- The core browser performs no network operations on its own. However, two
+  opt-in features can run arbitrary local code and reach the network: Lua
+  plugins (see below) and the MCP server's build/test/lint tools. Both execute
+  with your full permissions.
+
+## Lua Plugins
+
+Plugins are trusted user code and are **not** sandboxed. A loaded plugin has
+the full Lua standard library (`os.execute`, `io.*`, `require`, …) and can run
+commands, touch any accessible file, and use the network. `init.lua` autoloads
+on startup, so only install plugin code you trust. See `docs/PLUGINS.md` for
+details and how to disable the plugin runtime at build time.
+
+## MCP Server
+
+`fv --mcp-server <root>` speaks JSON-RPC over stdio (no network listener, no
+authentication; the trust boundary is whoever can spawn the process). It is
+intended for a local AI client.
+
+- File read/write/delete and listing tools confine paths to `<root>` by
+  canonicalizing and rejecting anything that resolves outside it.
+- `write_file` and `delete_file` additionally refuse sensitive paths such as
+  `.git/hooks`, `.git/config`, `.env`, and credential files.
+- `run_build`, `run_test`, `run_lint`, and `get_diagnostics` execute the
+  project's own toolchain (build scripts, test code, lint plugins). Exposing
+  these to an AI client is equivalent to allowing local code execution within
+  the project, so only point the server at repositories you trust.
 
 ## --on-select Callback
 

--- a/src/action/file.rs
+++ b/src/action/file.rs
@@ -2,8 +2,17 @@
 
 use std::path::{Path, PathBuf};
 
+/// Validate that a user-entered name is a single path component.
+///
+/// Prevents create/rename inputs like `../escape` or `/abs/path` from writing
+/// outside the directory the user is acting in.
+fn check_component(name: &str) -> anyhow::Result<()> {
+    crate::mcp::security::validate_component(name).map_err(|e| anyhow::anyhow!("{}", e))
+}
+
 /// Create a new file
 pub fn create_file(parent: &Path, name: &str) -> anyhow::Result<PathBuf> {
+    check_component(name)?;
     let path = parent.join(name);
     std::fs::OpenOptions::new()
         .write(true)
@@ -15,6 +24,7 @@ pub fn create_file(parent: &Path, name: &str) -> anyhow::Result<PathBuf> {
 
 /// Create a new directory
 pub fn create_dir(parent: &Path, name: &str) -> anyhow::Result<PathBuf> {
+    check_component(name)?;
     let path = parent.join(name);
     std::fs::create_dir(&path)
         .map_err(|e| anyhow::anyhow!("Failed to create directory '{}': {}", path.display(), e))?;
@@ -23,6 +33,7 @@ pub fn create_dir(parent: &Path, name: &str) -> anyhow::Result<PathBuf> {
 
 /// Rename a file or directory
 pub fn rename(path: &Path, new_name: &str) -> anyhow::Result<PathBuf> {
+    check_component(new_name)?;
     let parent = path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
@@ -58,6 +69,21 @@ pub fn copy_to(src: &Path, dest_dir: &Path) -> anyhow::Result<PathBuf> {
     } else {
         std::fs::copy(src, &dest)?;
     }
+    Ok(dest)
+}
+
+/// Move a file or directory into a destination directory.
+///
+/// Like [`copy_to`], the destination name is made unique (via the same
+/// `get_unique_path` helper) so an existing file with the same name is never
+/// silently overwritten.
+pub fn move_to(src: &Path, dest_dir: &Path) -> anyhow::Result<PathBuf> {
+    let file_name = src
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("Cannot move '{}': no filename", src.display()))?;
+    let dest = get_unique_path(&dest_dir.join(file_name));
+    std::fs::rename(src, &dest)
+        .map_err(|e| anyhow::anyhow!("Failed to move '{}': {}", src.display(), e))?;
     Ok(dest)
 }
 
@@ -232,6 +258,51 @@ mod tests {
         assert!(result.exists());
         assert!(result.is_dir());
         assert!(result.join("file.txt").exists());
+    }
+
+    #[test]
+    fn test_rename_rejects_traversal() {
+        let temp = TempDir::new().unwrap();
+        let original = temp.path().join("file.txt");
+        fs::write(&original, "content").unwrap();
+
+        // A rename target that escapes the directory must be refused, and the
+        // original must be left untouched.
+        assert!(rename(&original, "../escaped.txt").is_err());
+        assert!(rename(&original, "sub/nested.txt").is_err());
+        assert!(original.exists());
+        assert!(!temp.path().parent().unwrap().join("escaped.txt").exists());
+    }
+
+    #[test]
+    fn test_create_file_rejects_traversal() {
+        let temp = TempDir::new().unwrap();
+        assert!(create_file(temp.path(), "../evil.txt").is_err());
+        assert!(create_dir(temp.path(), "../evil_dir").is_err());
+    }
+
+    #[test]
+    fn test_move_to_unique_name() {
+        let temp = TempDir::new().unwrap();
+        let src_dir = temp.path().join("src");
+        fs::create_dir(&src_dir).unwrap();
+        let src = src_dir.join("file.txt");
+        fs::write(&src, "moved").unwrap();
+
+        let dest_dir = temp.path().join("dest");
+        fs::create_dir(&dest_dir).unwrap();
+        // Pre-existing file with the same name must NOT be overwritten.
+        fs::write(dest_dir.join("file.txt"), "existing").unwrap();
+
+        let result = move_to(&src, &dest_dir).unwrap();
+
+        assert!(!src.exists()); // moved away
+        assert_eq!(result.file_name().unwrap(), "file_1.txt");
+        assert_eq!(
+            fs::read_to_string(dest_dir.join("file.txt")).unwrap(),
+            "existing"
+        );
+        assert_eq!(fs::read_to_string(&result).unwrap(), "moved");
     }
 
     #[test]

--- a/src/action/file.rs
+++ b/src/action/file.rs
@@ -2,10 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
-/// Validate that a user-entered name is a single path component.
-///
-/// Prevents create/rename inputs like `../escape` or `/abs/path` from writing
-/// outside the directory the user is acting in.
+/// Reject create/rename names like `../escape` or `/abs/path` that would write
+/// outside the current directory.
 fn check_component(name: &str) -> anyhow::Result<()> {
     crate::mcp::security::validate_component(name).map_err(|e| anyhow::anyhow!("{}", e))
 }
@@ -72,11 +70,8 @@ pub fn copy_to(src: &Path, dest_dir: &Path) -> anyhow::Result<PathBuf> {
     Ok(dest)
 }
 
-/// Move a file or directory into a destination directory.
-///
-/// Like [`copy_to`], the destination name is made unique (via the same
-/// `get_unique_path` helper) so an existing file with the same name is never
-/// silently overwritten.
+/// Move a file or directory into `dest_dir`, allocating a unique name (like
+/// [`copy_to`]) so an existing same-named file is never silently overwritten.
 pub fn move_to(src: &Path, dest_dir: &Path) -> anyhow::Result<PathBuf> {
     let file_name = src
         .file_name()

--- a/src/ai_activity/replay.rs
+++ b/src/ai_activity/replay.rs
@@ -19,7 +19,7 @@ pub fn read_session_events(activity_log: &Path) -> Result<Vec<ActivityEvent>> {
     if !activity_log.exists() {
         return Ok(Vec::new());
     }
-    let raw = std::fs::read_to_string(activity_log)?;
+    let raw = crate::util::read_to_string_capped(activity_log, crate::util::MAX_STATE_FILE_BYTES)?;
     let mut out = Vec::new();
     for line in raw.lines() {
         let trimmed = line.trim();

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -783,7 +783,7 @@ CLAUDE CODE INTEGRATION:
                         session's event timeline. On Enter, the path of
                         the focused event is printed to stdout.
     plugin init [PATH]  Create plugin template file (default: ~/.config/fileview/plugins/init.lua)
-    plugin test PATH    Execute plugin file in sandbox and report status
+    plugin test PATH    Execute plugin file (trusted, unsandboxed) and report status
 
 CONFIG FILE:
     ~/.config/fileview/config.toml    Main configuration file

--- a/src/app/config_file.rs
+++ b/src/app/config_file.rs
@@ -228,7 +228,8 @@ impl ConfigFile {
         Self::config_path()
             .and_then(|path| {
                 if path.exists() {
-                    fs::read_to_string(&path).ok()
+                    crate::util::read_to_string_capped(&path, crate::util::MAX_STATE_FILE_BYTES)
+                        .ok()
                 } else {
                     None
                 }

--- a/src/app/video.rs
+++ b/src/app/video.rs
@@ -8,12 +8,8 @@ use std::process::Command;
 use std::sync::OnceLock;
 use std::time::Duration;
 
-/// Normalize a path for safe use as a positional ffmpeg/ffprobe argument.
-///
-/// ffmpeg and ffprobe treat any argument beginning with `-` as an option. A
-/// relative path whose first component starts with `-` is prefixed with `./`
-/// so a file named e.g. `-show_streams` cannot smuggle a flag (argument
-/// injection). Absolute paths already start with `/` and are returned as-is.
+/// Prefix a relative path starting with `-` with `./` so ffmpeg/ffprobe cannot
+/// parse the filename as an option flag (argument injection).
 fn safe_input_arg(path: &Path) -> PathBuf {
     if path.is_absolute() {
         return path.to_path_buf();

--- a/src/app/video.rs
+++ b/src/app/video.rs
@@ -8,6 +8,24 @@ use std::process::Command;
 use std::sync::OnceLock;
 use std::time::Duration;
 
+/// Normalize a path for safe use as a positional ffmpeg/ffprobe argument.
+///
+/// ffmpeg and ffprobe treat any argument beginning with `-` as an option. A
+/// relative path whose first component starts with `-` is prefixed with `./`
+/// so a file named e.g. `-show_streams` cannot smuggle a flag (argument
+/// injection). Absolute paths already start with `/` and are returned as-is.
+fn safe_input_arg(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    let starts_dash = path.to_str().map(|s| s.starts_with('-')).unwrap_or(false);
+    if starts_dash {
+        Path::new("./").join(path)
+    } else {
+        path.to_path_buf()
+    }
+}
+
 /// Cached ffmpeg path detection
 static FFMPEG_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
 
@@ -181,7 +199,7 @@ pub fn get_metadata(path: &Path) -> anyhow::Result<VideoMetadata> {
         .args(["-v", "quiet"])
         .args(["-print_format", "json"])
         .args(["-show_format", "-show_streams"])
-        .arg(path)
+        .arg(safe_input_arg(path))
         .output()?;
 
     if !output.status.success() {
@@ -348,7 +366,7 @@ pub fn extract_thumbnail(path: &Path) -> anyhow::Result<PathBuf> {
     let status = Command::new(ffmpeg)
         .args(["-y", "-ss", "1"])
         .arg("-i")
-        .arg(path)
+        .arg(safe_input_arg(path))
         .args(["-vframes", "1"])
         .args([
             "-vf",
@@ -364,7 +382,7 @@ pub fn extract_thumbnail(path: &Path) -> anyhow::Result<PathBuf> {
         let status = Command::new(ffmpeg)
             .args(["-y"])
             .arg("-i")
-            .arg(path)
+            .arg(safe_input_arg(path))
             .args(["-vframes", "1"])
             .args([
                 "-vf",

--- a/src/handler/action/file_ops.rs
+++ b/src/handler/action/file_ops.rs
@@ -34,10 +34,7 @@ pub fn handle(
                         }
                         ClipboardContent::Cut(paths) => {
                             for src in &paths {
-                                if let Some(name) = src.file_name() {
-                                    let new_path = dest.join(name);
-                                    std::fs::rename(src, new_path)?;
-                                }
+                                file_ops::move_to(src, &dest)?;
                             }
                             state.set_message(format!("Moved {} item(s)", paths.len()));
                         }

--- a/src/integrate/context_pack.rs
+++ b/src/integrate/context_pack.rs
@@ -301,11 +301,11 @@ fn collect_candidate_files(
     include_tests: bool,
 ) -> Vec<PathBuf> {
     if !selected_paths.is_empty() {
-        // Skip sensitive files (.env, credentials, keys) even when the user
-        // explicitly marked them, so secrets are not embedded into a pack.
+        // Skip sensitive files even when explicitly marked, so secrets are not
+        // embedded into a pack.
         return selected_paths
             .iter()
-            .filter(|p| p.is_file() && !crate::mcp::security::is_sensitive_path(p))
+            .filter(|p| p.is_file() && !is_sensitive(root, p))
             .cloned()
             .collect();
     }
@@ -333,9 +333,14 @@ fn collect_candidate_files(
     if out.is_empty() {
         collect_code_files_recursive(root, 0, max_depth, &mut out);
     }
-    out.into_iter()
-        .filter(|p| !crate::mcp::security::is_sensitive_path(p))
-        .collect()
+    out.into_iter().filter(|p| !is_sensitive(root, p)).collect()
+}
+
+/// Whether `path` is a sensitive file, judged on its location relative to
+/// `root` so the project's own directory name cannot trigger a false positive.
+fn is_sensitive(root: &Path, path: &Path) -> bool {
+    let rel = path.strip_prefix(root).unwrap_or(path);
+    crate::mcp::security::is_sensitive_path(rel)
 }
 
 fn collect_snippets(files: &[PathBuf], token_budget: usize) -> Vec<(PathBuf, String, usize)> {

--- a/src/integrate/context_pack.rs
+++ b/src/integrate/context_pack.rs
@@ -301,9 +301,11 @@ fn collect_candidate_files(
     include_tests: bool,
 ) -> Vec<PathBuf> {
     if !selected_paths.is_empty() {
+        // Skip sensitive files (.env, credentials, keys) even when the user
+        // explicitly marked them, so secrets are not embedded into a pack.
         return selected_paths
             .iter()
-            .filter(|p| p.is_file())
+            .filter(|p| p.is_file() && !crate::mcp::security::is_sensitive_path(p))
             .cloned()
             .collect();
     }
@@ -331,7 +333,9 @@ fn collect_candidate_files(
     if out.is_empty() {
         collect_code_files_recursive(root, 0, max_depth, &mut out);
     }
-    out.into_iter().collect()
+    out.into_iter()
+        .filter(|p| !crate::mcp::security::is_sensitive_path(p))
+        .collect()
 }
 
 fn collect_snippets(files: &[PathBuf], token_budget: usize) -> Vec<(PathBuf, String, usize)> {

--- a/src/integrate/plugin_cmd.rs
+++ b/src/integrate/plugin_cmd.rs
@@ -40,7 +40,8 @@ pub fn plugin_init(path: Option<&Path>) -> anyhow::Result<PathBuf> {
     Ok(plugin_path)
 }
 
-/// Execute a plugin file in sandboxed Lua runtime and return notifications.
+/// Execute a plugin file in the (unsandboxed, fully trusted) Lua runtime and
+/// return notifications. The plugin runs with the user's full permissions.
 pub fn plugin_test(path: &Path) -> anyhow::Result<Vec<String>> {
     let code = fs::read_to_string(path)?;
     let mut manager = PluginManager::new().map_err(|e| anyhow::anyhow!("{}", e))?;

--- a/src/integrate/session.rs
+++ b/src/integrate/session.rs
@@ -99,7 +99,7 @@ impl Session {
     /// Load named session from file.
     pub fn load_named(root: &Path, name: Option<&str>) -> io::Result<Self> {
         let path = Self::session_path(root, name);
-        let json = fs::read_to_string(path)?;
+        let json = crate::util::read_to_string_capped(&path, crate::util::MAX_STATE_FILE_BYTES)?;
         serde_json::from_str(&json).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 

--- a/src/integrate/snapshot.rs
+++ b/src/integrate/snapshot.rs
@@ -95,7 +95,7 @@ pub fn load_snapshot(root: &Path, name: &str) -> io::Result<Snapshot> {
             format!("snapshot '{}' not found at {}", name, path.display()),
         ));
     }
-    let text = fs::read_to_string(&path)?;
+    let text = crate::util::read_to_string_capped(&path, crate::util::MAX_STATE_FILE_BYTES)?;
     serde_json::from_str(&text).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,5 @@ pub mod mcp;
 pub mod plugin;
 pub mod render;
 pub mod tree;
+pub mod util;
 pub mod watcher;

--- a/src/mcp/handlers/analysis.rs
+++ b/src/mcp/handlers/analysis.rs
@@ -189,9 +189,7 @@ pub fn get_references(root: &Path, path: &str, symbol: &str) -> ToolCallResult {
         return error_result("Path is a directory, not a file");
     }
 
-    // Use ripgrep or grep to find references.
-    // `--` stops option parsing so a symbol beginning with `-` cannot be
-    // interpreted as a flag (argument injection).
+    // `--` stops option parsing so a `-`-prefixed symbol is not read as a flag.
     let (cmd, args) = if Command::new("rg").arg("--version").output().is_ok() {
         ("rg", vec!["-n", "--no-heading", "-w", "--", symbol])
     } else {
@@ -258,9 +256,8 @@ pub fn get_diagnostics(root: &Path, path: &str) -> ToolCallResult {
                 .output()
         }
         "py" => {
-            // Python: try ruff, then flake8, then pylint.
-            // Pass the validated canonical (absolute) path rather than the raw
-            // argument so a name beginning with `-` cannot be parsed as a flag.
+            // Pass the canonical (absolute) path so a `-`-prefixed name cannot
+            // be parsed as a flag.
             if Command::new("ruff").arg("--version").output().is_ok() {
                 Command::new("ruff")
                     .arg("check")

--- a/src/mcp/handlers/analysis.rs
+++ b/src/mcp/handlers/analysis.rs
@@ -189,11 +189,13 @@ pub fn get_references(root: &Path, path: &str, symbol: &str) -> ToolCallResult {
         return error_result("Path is a directory, not a file");
     }
 
-    // Use ripgrep or grep to find references
+    // Use ripgrep or grep to find references.
+    // `--` stops option parsing so a symbol beginning with `-` cannot be
+    // interpreted as a flag (argument injection).
     let (cmd, args) = if Command::new("rg").arg("--version").output().is_ok() {
-        ("rg", vec!["-n", "--no-heading", "-w", symbol])
+        ("rg", vec!["-n", "--no-heading", "-w", "--", symbol])
     } else {
-        ("grep", vec!["-rn", "-w", symbol])
+        ("grep", vec!["-rn", "-w", "--", symbol])
     };
 
     let output = Command::new(cmd).args(&args).current_dir(root).output();
@@ -256,14 +258,20 @@ pub fn get_diagnostics(root: &Path, path: &str) -> ToolCallResult {
                 .output()
         }
         "py" => {
-            // Python: try ruff, then flake8, then pylint
+            // Python: try ruff, then flake8, then pylint.
+            // Pass the validated canonical (absolute) path rather than the raw
+            // argument so a name beginning with `-` cannot be parsed as a flag.
             if Command::new("ruff").arg("--version").output().is_ok() {
                 Command::new("ruff")
-                    .args(["check", path])
+                    .arg("check")
+                    .arg(&canonical)
                     .current_dir(root)
                     .output()
             } else if Command::new("flake8").arg("--version").output().is_ok() {
-                Command::new("flake8").arg(path).current_dir(root).output()
+                Command::new("flake8")
+                    .arg(&canonical)
+                    .current_dir(root)
+                    .output()
             } else {
                 return success_result(
                     "No Python linter found (install ruff or flake8)".to_string(),
@@ -273,7 +281,8 @@ pub fn get_diagnostics(root: &Path, path: &str) -> ToolCallResult {
         "ts" | "tsx" => {
             // TypeScript: use tsc
             Command::new("npx")
-                .args(["tsc", "--noEmit", path])
+                .args(["tsc", "--noEmit"])
+                .arg(&canonical)
                 .current_dir(root)
                 .output()
         }
@@ -286,7 +295,8 @@ pub fn get_diagnostics(root: &Path, path: &str) -> ToolCallResult {
                 .is_ok()
             {
                 Command::new("npx")
-                    .args(["eslint", "--format", "compact", path])
+                    .args(["eslint", "--format", "compact"])
+                    .arg(&canonical)
                     .current_dir(root)
                     .output()
             } else {

--- a/src/mcp/handlers/file.rs
+++ b/src/mcp/handlers/file.rs
@@ -155,9 +155,9 @@ pub fn write_file(root: &Path, path: &str, content: &str, create_dirs: bool) -> 
         Err(e) => return error_result(&e.to_string()),
     };
 
-    // Refuse to write to sensitive files (e.g. .git/hooks, .git/config, .env,
-    // credentials). Writing a git hook would execute on the next git command.
-    if is_sensitive_path(&target) {
+    // Refuse sensitive files (a planted git hook would run on the next git
+    // command). Check the relative path to avoid false positives on the root.
+    if is_sensitive_path(Path::new(path)) {
         return error_result(&format!("Refusing to write to sensitive path: {}", path));
     }
 
@@ -194,8 +194,8 @@ pub fn delete_file(root: &Path, path: &str, recursive: bool, use_trash: bool) ->
         }
     }
 
-    // Refuse to delete sensitive files (e.g. .git internals, credentials).
-    if is_sensitive_path(&canonical) {
+    // Refuse sensitive files. Check the relative path to avoid false positives.
+    if is_sensitive_path(Path::new(path)) {
         return error_result(&format!("Refusing to delete sensitive path: {}", path));
     }
 
@@ -245,9 +245,8 @@ pub fn search_code(root: &Path, pattern: &str, path: Option<&str>) -> ToolCallRe
         return error_result("Search pattern contains invalid characters");
     }
 
-    // Try ripgrep first, fall back to grep.
-    // The `--` separator stops option parsing so a pattern beginning with `-`
-    // (e.g. `--pre <cmd>` for ripgrep) cannot be smuggled in as a flag.
+    // `--` stops option parsing so a `-`-prefixed pattern (e.g. `rg --pre`)
+    // cannot be smuggled in as a flag.
     let (cmd, args) = if Command::new("rg").arg("--version").output().is_ok() {
         ("rg", vec!["-n", "--no-heading", "--", pattern])
     } else {
@@ -341,6 +340,20 @@ mod tests {
     fn test_write_file_allows_normal_path() {
         let temp = tempdir().unwrap();
         let root = temp.path().canonicalize().unwrap();
+
+        let result = write_file(&root, "src/main.rs", "fn main() {}", true);
+        assert_eq!(result.is_error, None);
+        assert!(root.join("src/main.rs").exists());
+    }
+
+    #[test]
+    fn test_write_file_allows_normal_path_under_sensitive_named_root() {
+        // A project directory whose own name contains a trigger word (e.g.
+        // "credentials") must not block writes to ordinary files inside it.
+        let temp = tempdir().unwrap();
+        let root = temp.path().join("credentials-app");
+        fs::create_dir_all(&root).unwrap();
+        let root = root.canonicalize().unwrap();
 
         let result = write_file(&root, "src/main.rs", "fn main() {}", true);
         assert_eq!(result.is_error, None);

--- a/src/mcp/handlers/file.rs
+++ b/src/mcp/handlers/file.rs
@@ -7,7 +7,9 @@ use std::path::Path;
 use std::process::Command;
 
 use super::{error_result, success_result, ToolCallResult, ToolContent};
-use crate::mcp::security::{truncate_entry_name, validate_new_path, validate_path};
+use crate::mcp::security::{
+    is_sensitive_path, truncate_entry_name, validate_new_path, validate_path,
+};
 
 /// List directory contents
 pub fn list_directory(root: &Path, path: Option<&str>) -> ToolCallResult {
@@ -153,6 +155,12 @@ pub fn write_file(root: &Path, path: &str, content: &str, create_dirs: bool) -> 
         Err(e) => return error_result(&e.to_string()),
     };
 
+    // Refuse to write to sensitive files (e.g. .git/hooks, .git/config, .env,
+    // credentials). Writing a git hook would execute on the next git command.
+    if is_sensitive_path(&target) {
+        return error_result(&format!("Refusing to write to sensitive path: {}", path));
+    }
+
     // Create parent directories if requested
     if create_dirs {
         if let Some(parent) = target.parent() {
@@ -184,6 +192,11 @@ pub fn delete_file(root: &Path, path: &str, recursive: bool, use_trash: bool) ->
         if canonical == root_canonical {
             return error_result("Cannot delete root directory");
         }
+    }
+
+    // Refuse to delete sensitive files (e.g. .git internals, credentials).
+    if is_sensitive_path(&canonical) {
+        return error_result(&format!("Refusing to delete sensitive path: {}", path));
     }
 
     let is_dir = canonical.is_dir();
@@ -232,11 +245,13 @@ pub fn search_code(root: &Path, pattern: &str, path: Option<&str>) -> ToolCallRe
         return error_result("Search pattern contains invalid characters");
     }
 
-    // Try ripgrep first, fall back to grep
+    // Try ripgrep first, fall back to grep.
+    // The `--` separator stops option parsing so a pattern beginning with `-`
+    // (e.g. `--pre <cmd>` for ripgrep) cannot be smuggled in as a flag.
     let (cmd, args) = if Command::new("rg").arg("--version").output().is_ok() {
-        ("rg", vec!["-n", "--no-heading", pattern])
+        ("rg", vec!["-n", "--no-heading", "--", pattern])
     } else {
-        ("grep", vec!["-rn", pattern])
+        ("grep", vec!["-rn", "--", pattern])
     };
 
     let search_path = match path {
@@ -292,5 +307,55 @@ pub fn search_code(root: &Path, pattern: &str, path: Option<&str>) -> ToolCallRe
             success_result(result)
         }
         Err(e) => error_result(&format!("Failed to run search: {}", e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_write_file_refuses_sensitive_path() {
+        let temp = tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+
+        let result = write_file(&root, ".env", "SECRET=1", false);
+        assert_eq!(result.is_error, Some(true));
+        assert!(!root.join(".env").exists());
+    }
+
+    #[test]
+    fn test_write_file_refuses_git_hook() {
+        let temp = tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        fs::create_dir_all(root.join(".git/hooks")).unwrap();
+
+        let result = write_file(&root, ".git/hooks/pre-commit", "#!/bin/sh\nevil", true);
+        assert_eq!(result.is_error, Some(true));
+        assert!(!root.join(".git/hooks/pre-commit").exists());
+    }
+
+    #[test]
+    fn test_write_file_allows_normal_path() {
+        let temp = tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+
+        let result = write_file(&root, "src/main.rs", "fn main() {}", true);
+        assert_eq!(result.is_error, None);
+        assert!(root.join("src/main.rs").exists());
+    }
+
+    #[test]
+    fn test_delete_file_refuses_sensitive_path() {
+        let temp = tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join(".git/config"), "[core]").unwrap();
+
+        let result = delete_file(&root, ".git/config", false, false);
+        assert_eq!(result.is_error, Some(true));
+        assert!(root.join(".git/config").exists());
     }
 }

--- a/src/mcp/handlers/project.rs
+++ b/src/mcp/handlers/project.rs
@@ -153,13 +153,10 @@ pub fn run_test(root: &Path, path: Option<&str>, filter: Option<&str>) -> ToolCa
         }
     };
 
-    // Add path filter if specified
+    // Add path filter if specified. The value may be a test-name filter rather
+    // than a real path (cargo, pytest `file::test`), so only reject option-like
+    // values instead of requiring an existing path.
     if let Some(p) = path {
-        // Confine the path to the project root and reject anything that would
-        // be parsed as an option flag by the test runner.
-        if let Err(e) = validate_path(root, p) {
-            return error_result(&e.to_string());
-        }
         if let Err(e) = reject_option_like(p) {
             return error_result(&e.to_string());
         }

--- a/src/mcp/handlers/project.rs
+++ b/src/mcp/handlers/project.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::process::Command;
 
 use super::{error_result, success_result, ToolCallResult};
-use crate::mcp::security::validate_path;
+use crate::mcp::security::{reject_option_like, validate_path};
 
 /// Detected project type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -155,6 +155,14 @@ pub fn run_test(root: &Path, path: Option<&str>, filter: Option<&str>) -> ToolCa
 
     // Add path filter if specified
     if let Some(p) = path {
+        // Confine the path to the project root and reject anything that would
+        // be parsed as an option flag by the test runner.
+        if let Err(e) = validate_path(root, p) {
+            return error_result(&e.to_string());
+        }
+        if let Err(e) = reject_option_like(p) {
+            return error_result(&e.to_string());
+        }
         match project_type {
             ProjectType::Rust => {
                 // Cargo test with path
@@ -179,6 +187,9 @@ pub fn run_test(root: &Path, path: Option<&str>, filter: Option<&str>) -> ToolCa
 
     // Add name filter if specified
     if let Some(f) = filter {
+        if let Err(e) = reject_option_like(f) {
+            return error_result(&e.to_string());
+        }
         match project_type {
             ProjectType::Rust => {
                 if !args.contains(&"--".to_string()) {
@@ -242,6 +253,9 @@ pub fn run_lint(root: &Path, path: Option<&str>, fix: bool) -> ToolCallResult {
 
     // Add path filter if specified
     if let Some(p) = path {
+        if let Err(e) = reject_option_like(p) {
+            return error_result(&e.to_string());
+        }
         match validate_path(root, p) {
             Ok(_) => {
                 // Replace "." with specific path

--- a/src/mcp/security.rs
+++ b/src/mcp/security.rs
@@ -27,9 +27,8 @@ pub const MAX_BATCH_SIZE: usize = 1000;
 pub fn validate_path(root: &Path, path: &str) -> Result<PathBuf> {
     let target = root.join(path);
 
-    // Compare against the canonicalized root so that a root reached through a
-    // symlink (e.g. /tmp -> /private/tmp on macOS) does not make legitimate
-    // in-root paths spuriously fail the containment check.
+    // Compare against the canonicalized root so a symlinked root does not make
+    // in-root paths fail the containment check.
     let root_canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
 
     match target.canonicalize() {
@@ -46,12 +45,9 @@ pub fn validate_path(root: &Path, path: &str) -> Result<PathBuf> {
     }
 }
 
-/// Validate that a user-supplied name refers to a single path component.
-///
-/// Used by the interactive create/rename operations so that a name like
-/// `../../etc/passwd` or an absolute path cannot escape the directory the user
-/// is acting in. Rejects empty names, `.`/`..`, and anything containing a path
-/// separator.
+/// Validate that a user-supplied name is a single path component, so create and
+/// rename cannot escape the current directory. Rejects empty, `.`/`..`, and any
+/// path separator.
 pub fn validate_component(name: &str) -> Result<()> {
     if name.is_empty() {
         return Err(FileviewError::path(name, "name cannot be empty"));
@@ -68,13 +64,8 @@ pub fn validate_component(name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Reject a value that would be interpreted as an option flag by an external
-/// tool (i.e. begins with `-`).
-///
-/// Search patterns, symbol names and test/lint filters are passed positionally
-/// to tools like `rg`, `grep`, `pytest` and `eslint`. Even with a `--`
-/// separator this is a cheap defence-in-depth against argument injection such
-/// as `rg --pre <command>` or `eslint --rulesdir <dir>`.
+/// Reject a value that an external tool would parse as an option flag (begins
+/// with `-`). Defence-in-depth against argument injection like `rg --pre`.
 pub fn reject_option_like(value: &str) -> Result<()> {
     if value.starts_with('-') {
         return Err(FileviewError::mcp(format!(
@@ -148,14 +139,11 @@ pub fn is_root(root: &Path, path: &Path) -> bool {
     }
 }
 
-/// Truncate a string if it exceeds the maximum length.
-///
-/// Operates on byte length but slices on a UTF-8 character boundary so that a
-/// maliciously long multibyte name cannot trigger a panic.
+/// Truncate a string to `max_len` bytes, slicing on a UTF-8 char boundary so a
+/// multibyte name cannot trigger a panic.
 pub fn truncate_string(s: String, max_len: usize) -> String {
     if s.len() > max_len {
         let mut end = max_len.saturating_sub(3);
-        // Walk back to the nearest char boundary so we never slice mid-codepoint.
         while end > 0 && !s.is_char_boundary(end) {
             end -= 1;
         }

--- a/src/mcp/security.rs
+++ b/src/mcp/security.rs
@@ -27,9 +27,14 @@ pub const MAX_BATCH_SIZE: usize = 1000;
 pub fn validate_path(root: &Path, path: &str) -> Result<PathBuf> {
     let target = root.join(path);
 
+    // Compare against the canonicalized root so that a root reached through a
+    // symlink (e.g. /tmp -> /private/tmp on macOS) does not make legitimate
+    // in-root paths spuriously fail the containment check.
+    let root_canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+
     match target.canonicalize() {
         Ok(canonical) => {
-            if !canonical.starts_with(root) {
+            if !canonical.starts_with(&root_canonical) {
                 return Err(FileviewError::path(
                     canonical,
                     "path is outside root directory",
@@ -39,6 +44,45 @@ pub fn validate_path(root: &Path, path: &str) -> Result<PathBuf> {
         }
         Err(e) => Err(FileviewError::path(target, format!("invalid path: {}", e))),
     }
+}
+
+/// Validate that a user-supplied name refers to a single path component.
+///
+/// Used by the interactive create/rename operations so that a name like
+/// `../../etc/passwd` or an absolute path cannot escape the directory the user
+/// is acting in. Rejects empty names, `.`/`..`, and anything containing a path
+/// separator.
+pub fn validate_component(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(FileviewError::path(name, "name cannot be empty"));
+    }
+    if name == "." || name == ".." {
+        return Err(FileviewError::path(name, "name cannot be '.' or '..'"));
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err(FileviewError::path(
+            name,
+            "name cannot contain a path separator",
+        ));
+    }
+    Ok(())
+}
+
+/// Reject a value that would be interpreted as an option flag by an external
+/// tool (i.e. begins with `-`).
+///
+/// Search patterns, symbol names and test/lint filters are passed positionally
+/// to tools like `rg`, `grep`, `pytest` and `eslint`. Even with a `--`
+/// separator this is a cheap defence-in-depth against argument injection such
+/// as `rg --pre <command>` or `eslint --rulesdir <dir>`.
+pub fn reject_option_like(value: &str) -> Result<()> {
+    if value.starts_with('-') {
+        return Err(FileviewError::mcp(format!(
+            "argument '{}' may not begin with '-'",
+            value
+        )));
+    }
+    Ok(())
 }
 
 /// Validate a path for a new file that doesn't exist yet.
@@ -105,9 +149,17 @@ pub fn is_root(root: &Path, path: &Path) -> bool {
 }
 
 /// Truncate a string if it exceeds the maximum length.
+///
+/// Operates on byte length but slices on a UTF-8 character boundary so that a
+/// maliciously long multibyte name cannot trigger a panic.
 pub fn truncate_string(s: String, max_len: usize) -> String {
     if s.len() > max_len {
-        format!("{}...", &s[..max_len.saturating_sub(3)])
+        let mut end = max_len.saturating_sub(3);
+        // Walk back to the nearest char boundary so we never slice mid-codepoint.
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
     } else {
         s
     }
@@ -225,5 +277,43 @@ mod tests {
         assert!(validate_batch_size(100).is_ok());
         assert!(validate_batch_size(1000).is_ok());
         assert!(validate_batch_size(1001).is_err());
+    }
+
+    #[test]
+    fn test_truncate_string_multibyte_no_panic() {
+        // A long string of 3-byte characters must not panic when the cut point
+        // lands inside a multibyte codepoint.
+        let s = "あ".repeat(3000); // 9000 bytes
+        let truncated = truncate_string(s, 100);
+        assert!(truncated.len() <= 100);
+        assert!(truncated.ends_with("..."));
+        // Result must still be valid UTF-8 (guaranteed by String, but assert
+        // it round-trips through chars without loss of the boundary).
+        assert!(truncated.chars().count() > 0);
+    }
+
+    #[test]
+    fn test_validate_component_ok() {
+        assert!(validate_component("file.txt").is_ok());
+        assert!(validate_component("my-dir_2").is_ok());
+    }
+
+    #[test]
+    fn test_validate_component_rejects_traversal() {
+        assert!(validate_component("").is_err());
+        assert!(validate_component(".").is_err());
+        assert!(validate_component("..").is_err());
+        assert!(validate_component("../evil").is_err());
+        assert!(validate_component("sub/dir").is_err());
+        assert!(validate_component("/abs/path").is_err());
+        assert!(validate_component("a\\b").is_err());
+    }
+
+    #[test]
+    fn test_reject_option_like() {
+        assert!(reject_option_like("pattern").is_ok());
+        assert!(reject_option_like("foo_bar").is_ok());
+        assert!(reject_option_like("--pre").is_err());
+        assert!(reject_option_like("-rf").is_err());
     }
 }

--- a/src/render/preview/archive.rs
+++ b/src/render/preview/archive.rs
@@ -220,8 +220,7 @@ pub fn render_archive_preview(
 
         let date_str = entry.modified.as_deref().unwrap_or("");
 
-        // Calculate name display width. Truncate on a UTF-8 char boundary so a
-        // multibyte archive entry name cannot trigger a slice panic.
+        // Truncate on a char boundary to avoid a panic on multibyte names.
         let max_name_width = area.width.saturating_sub(24) as usize;
         let display_name =
             crate::mcp::security::truncate_string(entry.name.clone(), max_name_width);

--- a/src/render/preview/archive.rs
+++ b/src/render/preview/archive.rs
@@ -220,13 +220,11 @@ pub fn render_archive_preview(
 
         let date_str = entry.modified.as_deref().unwrap_or("");
 
-        // Calculate name display width
+        // Calculate name display width. Truncate on a UTF-8 char boundary so a
+        // multibyte archive entry name cannot trigger a slice panic.
         let max_name_width = area.width.saturating_sub(24) as usize;
-        let display_name = if entry.name.len() > max_name_width {
-            format!("{}...", &entry.name[..max_name_width.saturating_sub(3)])
-        } else {
-            entry.name.clone()
-        };
+        let display_name =
+            crate::mcp::security::truncate_string(entry.name.clone(), max_name_width);
 
         lines.push(Line::from(vec![
             Span::styled(format!("  {} ", icon), Style::default().fg(color)),

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,18 +3,11 @@
 use std::io;
 use std::path::Path;
 
-/// Default cap for reading config/session/state files into memory (16 MiB).
-///
-/// These files live under the user's own config/cache/repo, so this is purely
-/// defence-in-depth against a maliciously huge file causing unbounded memory
-/// use during parsing rather than a hard security boundary.
+/// Cap for reading config/session/state files into memory (16 MiB).
+/// Defence-in-depth against an oversized file exhausting memory during parsing.
 pub const MAX_STATE_FILE_BYTES: u64 = 16 * 1024 * 1024;
 
-/// Read a file to a string, refusing to read more than `max_bytes`.
-///
-/// Returns an `InvalidData` error if the file exceeds the cap, so callers that
-/// already handle `io::Result` degrade gracefully instead of allocating an
-/// arbitrarily large buffer.
+/// Read a file to a string, returning `InvalidData` if it exceeds `max_bytes`.
 pub fn read_to_string_capped(path: &Path, max_bytes: u64) -> io::Result<String> {
     let len = std::fs::metadata(path)?.len();
     if len > max_bytes {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,58 @@
+//! Small shared utilities.
+
+use std::io;
+use std::path::Path;
+
+/// Default cap for reading config/session/state files into memory (16 MiB).
+///
+/// These files live under the user's own config/cache/repo, so this is purely
+/// defence-in-depth against a maliciously huge file causing unbounded memory
+/// use during parsing rather than a hard security boundary.
+pub const MAX_STATE_FILE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Read a file to a string, refusing to read more than `max_bytes`.
+///
+/// Returns an `InvalidData` error if the file exceeds the cap, so callers that
+/// already handle `io::Result` degrade gracefully instead of allocating an
+/// arbitrarily large buffer.
+pub fn read_to_string_capped(path: &Path, max_bytes: u64) -> io::Result<String> {
+    let len = std::fs::metadata(path)?.len();
+    if len > max_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "file {} is {} bytes, exceeding the {}-byte limit",
+                path.display(),
+                len,
+                max_bytes
+            ),
+        ));
+    }
+    std::fs::read_to_string(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn reads_small_file() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("ok.txt");
+        fs::write(&p, "hello").unwrap();
+        assert_eq!(
+            read_to_string_capped(&p, MAX_STATE_FILE_BYTES).unwrap(),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_file() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("big.txt");
+        fs::write(&p, "0123456789").unwrap();
+        assert!(read_to_string_capped(&p, 5).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

A security review (covering the vulnerability classes injection, SSRF, path traversal, unsafe deserialization, and secret exposure) surfaced several issues, concentrated in the MCP server and the interactive file operations. This PR addresses all of them. There is no change to the default keyboard-driven browsing experience.

The core browser was already in good shape: filename-driven shell injection is blocked (callbacks/hooks/custom preview escape or use env vars), archive preview is listing-only (no zip-slip), `regex` is linear-time, and serde has no pickle-style RCE. The fixes below target the remaining edges.

## Changes

### MCP server
- `write_file` / `delete_file` now refuse sensitive paths (`.git/hooks`, `.git/config`, `.env`, credentials). Previously `is_sensitive_path` existed but was never called, so an AI client could write `.git/hooks/pre-commit` and get code execution on the next git command.
- `search_code`, `get_references`, `get_diagnostics`, `run_test`, `run_lint`: caller-supplied pattern/symbol/path/filter can no longer be parsed as an option flag (argument injection like `rg --pre <cmd>` or `eslint --rulesdir <dir>`). Applied `--` separators, validated canonical paths, and a leading-dash rejection.
- `validate_path` now compares against the canonicalized root, so a root reached through a symlink (e.g. `/tmp` -> `/private/tmp`) no longer rejects legitimate in-root paths.

### Interactive file operations
- `create`, `rename`, and bulk-rename reject names containing a path separator or `..`, so input can no longer escape the target directory.
- Cut/paste (move) allocates a unique destination name instead of silently overwriting an existing same-named file.

### Robustness / defence-in-depth
- `ffprobe`/`ffmpeg` preview guards against a leading-dash filename being parsed as an option.
- Context pack skips sensitive files (e.g. `.env`) even when explicitly selected.
- UTF-8 boundary-safe truncation for archive entry names and MCP entry names (was a potential panic on multibyte names).
- Size-capped reads for config/session/snapshot/activity files.

### Documentation
- `docs/PLUGINS.md` and `docs/SECURITY.md` corrected: Lua plugins are trusted, unsandboxed code with full system access (the previous "sandboxed" claim and "no network operations" statement were inaccurate). Documented the MCP server's stdio/local trust model and that build/test/lint tools execute project code.

## Notes / trade-offs
- The sensitive-path guard uses a broad substring match, so a legitimate file whose path contains e.g. `secrets` would also be refused for write/delete. This was an accepted trade-off favouring safety; read access is unaffected.

## Testing
- New unit tests: sensitive-path refusal (write/delete), traversal rejection in create/rename, `move_to` unique-name, multibyte truncation, `validate_component`, `reject_option_like`, capped reads.
- `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings` (default and `--no-default-features`), `cargo test` (1057 passed), and `RUSTDOCFLAGS=-D warnings cargo doc` all pass locally.