### PR TITLE
Release 2.7.4: security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.7.4] - 2026-05-29
 
 Security hardening across the MCP server, interactive file operations, the
 external-tool integrations, and the documentation. No change to the default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "fileview"
-version = "2.7.3"
+version = "2.7.4"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fileview"
-version = "2.7.3"
+version = "2.7.4"
 edition = "2021"
 rust-version = "1.90.0"  # MSRV - Minimum Supported Rust Version
 description = "A fast, keyboard-driven TUI file browser with previews and git"


### PR DESCRIPTION
Cuts the 2.7.4 release. Bumps the version to 2.7.4 and finalizes the CHANGELOG `[Unreleased]` section (now `[2.7.4]`). No source-code or behaviour changes beyond what already merged in #220.

The 2.7.4 entry covers the security hardening landed in #220:

- MCP `write_file`/`delete_file` refuse sensitive paths (`.git/hooks`, `.git/config`, `.env`, credentials).
- MCP search/references/diagnostics/test/lint: `--` separators, validated canonical paths, and leading-dash rejection to stop argument injection.
- Interactive create/rename/bulk-rename reject path separators and `..`; move allocates a unique destination instead of overwriting.
- `ffprobe`/`ffmpeg` guard against leading-dash filenames; context pack skips sensitive files.
- `validate_path` canonicalizes the root; UTF-8-safe name truncation; size-capped state-file reads.
- Docs corrected: Lua plugins are trusted/unsandboxed; documented the MCP server trust model.

After merge, push the `v2.7.4` tag to trigger the release build.